### PR TITLE
Add End Game Self Damage Stat

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -109,6 +109,7 @@ typedef struct player_stats_s {
 	float    dmg_g; // damage given
 	float    dmg_g_rl; // virtual given rl damage
 	float    dmg_team;  // damage to team
+	float    dmg_self;  // damage to team
 // { k_dmgfrags
 	float    dmg_frags; // frags awarded from damage (CA)
 // }

--- a/src/combat.c
+++ b/src/combat.c
@@ -819,44 +819,53 @@ void T_Damage( gedict_t * targ, gedict_t * inflictor, gedict_t * attacker, float
 	}
 
 	// update damage stats like: give/taked/team damage
-	if ( attacker->ct == ctPlayer && targ->ct == ctPlayer && attacker != targ )
+	if ( attacker->ct == ctPlayer && targ->ct == ctPlayer )
 	{
-		// damage
-
-		if ( tp_num() && streq(attackerteam, targteam) )
+		if ( attacker == targ )
 		{
-			attacker->ps.dmg_team += dmg_dealt;
+			// self damage
+
+			attacker->ps.dmg_self += dmg_dealt;
 		}
-		else 
+		else
 		{
-			attacker->ps.dmg_g += dmg_dealt;
-			targ->ps.dmg_t     += dmg_dealt;
-		}
+			// damage
 
-		// real hits
-
-		if ( take || save )
-		{
-			if ( dtRL == targ->deathtype )
-				attacker->ps.wpn[wpRL].rhits++;
-
-			if ( dtGL == targ->deathtype )
-				attacker->ps.wpn[wpGL].rhits++;
-		}
-
-		// virtual hits
-
-		if ( virtual_take || save )
-		{
-			if ( dtRL == targ->deathtype )
+			if ( tp_num() && streq(attackerteam, targteam) )
 			{
-				attacker->ps.wpn[wpRL].vhits++;
-				// virtual given rl damage
-				attacker->ps.dmg_g_rl += ( virtual_take + save );
+				attacker->ps.dmg_team += dmg_dealt;
+			}
+			else 
+			{
+				attacker->ps.dmg_g += dmg_dealt;
+				targ->ps.dmg_t     += dmg_dealt;
 			}
 
-			if ( dtGL == targ->deathtype )
-				attacker->ps.wpn[wpGL].vhits++;
+			// real hits
+
+			if ( take || save )
+			{
+				if ( dtRL == targ->deathtype )
+					attacker->ps.wpn[wpRL].rhits++;
+
+				if ( dtGL == targ->deathtype )
+					attacker->ps.wpn[wpGL].rhits++;
+			}
+
+			// virtual hits
+
+			if ( virtual_take || save )
+			{
+				if ( dtRL == targ->deathtype )
+				{
+					attacker->ps.wpn[wpRL].vhits++;
+					// virtual given rl damage
+					attacker->ps.dmg_g_rl += ( virtual_take + save );
+				}
+
+				if ( dtGL == targ->deathtype )
+					attacker->ps.wpn[wpGL].vhits++;
+			}
 		}
 	}
 

--- a/src/match.c
+++ b/src/match.c
@@ -393,7 +393,7 @@ int maxspree, maxspree_q;
 
 void OnePlayerStats(gedict_t *p, int tp)
 {
-	float	dmg_g, dmg_t, dmg_team, dmg_g_rl;
+	float	dmg_g, dmg_t, dmg_team, dmg_self, dmg_g_rl;
 	int   ra, ya, ga;
 	int   mh, d_rl, k_rl, t_rl;
 	int   quad, pent, ring;
@@ -404,6 +404,7 @@ void OnePlayerStats(gedict_t *p, int tp)
 	dmg_g_rl = p->ps.dmg_g_rl;
 	dmg_t = p->ps.dmg_t;
 	dmg_team = p->ps.dmg_team;
+	dmg_self = p->ps.dmg_self;
 	ra    = p->ps.itm[itRA].tooks;
 	ya    = p->ps.itm[itYA].tooks;
 	ga    = p->ps.itm[itGA].tooks;
@@ -510,8 +511,8 @@ void OnePlayerStats(gedict_t *p, int tp)
 				redtext("Took"), t_rl, redtext("Killed"), k_rl, redtext("Dropped"), d_rl);
 
 		// damage
-		G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),
-			redtext("Tkn"), dmg_t, redtext("Gvn"), dmg_g, redtext("Tm"), dmg_team);
+		G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),
+			redtext("Tkn"), dmg_t, redtext("Gvn"), dmg_g, redtext("Tm"), dmg_team, redtext("Self"), dmg_self);
 
 		if ( isDuel() )
 		{


### PR DESCRIPTION
Chose not to do total team self damage for team stats, but that would be easy to add.

![self-dmg](https://cloud.githubusercontent.com/assets/11351/11265859/a02f5926-8e54-11e5-9774-0ecc2d885c1f.png)
