### PR TITLE
Add End Game Time Stats

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -153,6 +153,9 @@ typedef struct player_stats_s {
 	int spree_max;			// largest spree throughout game
 	int spree_max_q;		// largest quad spree throughout game
 
+	// time stats
+	float control_time; // time spent in control
+
 	// rocket arena
 	int wins;	//number of wins they have
 	int loses;	//number of loses they have
@@ -457,6 +460,7 @@ typedef struct gedict_s {
 
 	player_stats_t ps;		// store player statistic here, like taken armors etc...
 
+	float control_start_time; // time when player gained control
 	float q_pickup_time;	// time then u took quad
 	float p_pickup_time;	// time then u took pent
 	float r_pickup_time;	// time then u took ring

--- a/src/match.c
+++ b/src/match.c
@@ -347,6 +347,10 @@ void SummaryTPStats()
 		// damage
 		G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),
 					redtext("Tkn"), tmStats[i].dmg_t, redtext("Gvn"), tmStats[i].dmg_g, redtext("Tm"), tmStats[i].dmg_team);
+
+		// times
+		G_bprint(2, "%s: %s:%d\n", redtext("    Time"),
+					redtext("Quad"), (int)tmStats[i].itm[itQUAD].time);
 	}
 
 	G_bprint(2, "žžžžžžžžžžžžžžžžžžžžžžžžžžžžžžžžžŸ\n");
@@ -512,6 +516,21 @@ void OnePlayerStats(gedict_t *p, int tp)
 		// damage
 		G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),
 			redtext("Tkn"), dmg_t, redtext("Gvn"), dmg_g, redtext("Tm"), dmg_team);
+
+		// times
+		if ( g_globalvars.time - match_start_time > 0 )
+		{
+			if ( isDuel() )
+			{
+				G_bprint(2, "%s: %s:%d (%d%%)\n", redtext("    Time"),
+					redtext("Control"), (int)p->ps.control_time, (int)((p->ps.control_time / ( g_globalvars.time - match_start_time )) * 100));
+			}
+			else
+			{
+				G_bprint(2, "%s: %s:%d\n", redtext("    Time"),
+					redtext("Quad"), (int)p->ps.itm[itQUAD].time);
+			}
+		}
 
 		if ( isDuel() )
 		{
@@ -1287,6 +1306,12 @@ void EM_CorrectStats()
 		adjust_pickup_time( &p->q_pickup_time, &p->ps.itm[itQUAD].time );
 		adjust_pickup_time( &p->p_pickup_time, &p->ps.itm[itPENT].time );
 		adjust_pickup_time( &p->r_pickup_time, &p->ps.itm[itRING].time );
+
+		if ( p->control_start_time )
+		{
+			p->ps.control_time += g_globalvars.time - p->control_start_time;
+			p->control_start_time = 0;
+		}
 
 		if ( isCTF() ) { // if a player ends the game with a rune adjust their rune time
 


### PR DESCRIPTION
For Duel: Include a time / % time player was in control.

Simple heuristic for control right now (start = spree > 2, end = death / game over).

![time-in-control](https://cloud.githubusercontent.com/assets/11351/11296680/7966d650-8f28-11e5-8264-ccd73200a541.png)

For Team: Include a time per player and per team quad was held.

![time-with-quad-team](https://cloud.githubusercontent.com/assets/11351/11296718/b437746a-8f28-11e5-9b46-7c545b156876.png)

![time-with-quad-team-2](https://cloud.githubusercontent.com/assets/11351/11296721/b8994768-8f28-11e5-9b8b-7ac77735338f.png)


This could probably be excluded if all players have 0 (e.g. dm4) but so many stats already dump 0 for everyone in most cases that I just left it in.