### PR TITLE
Ending a game with break should show stats and save demo

### DIFF
--- a/src/vote.c
+++ b/src/vote.c
@@ -340,7 +340,7 @@ void vote_check_break ()
 
 		G_bprint(2, "%s\n", redtext("Match stopped by majority vote"));
 
-		EndMatch( 1 );
+		EndMatch( 0 );
 
 		return;
 	}


### PR DESCRIPTION
A few players mentioned this on the [quakeworld.nu forums](http://www.quakeworld.nu/forum/topic/6688/101856/qw-tweaks-and-ideas-brainstorm/#101856). So here is a fix.
