### PR TITLE
Add End Game Enemy Weapon Damage Stat

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -109,6 +109,7 @@ typedef struct player_stats_s {
 	float    dmg_g; // damage given
 	float    dmg_g_rl; // virtual given rl damage
 	float    dmg_team;  // damage to team
+	float    dmg_eweapon;  // damage to enemy weapons
 // { k_dmgfrags
 	float    dmg_frags; // frags awarded from damage (CA)
 // }

--- a/src/combat.c
+++ b/src/combat.c
@@ -831,6 +831,13 @@ void T_Damage( gedict_t * targ, gedict_t * inflictor, gedict_t * attacker, float
 		{
 			attacker->ps.dmg_g += dmg_dealt;
 			targ->ps.dmg_t     += dmg_dealt;
+
+			// damage to enemy weapon
+			int items = targ->s.v.items;
+			if ( items & (IT_ROCKET_LAUNCHER | IT_LIGHTNING) )
+			{
+				attacker->ps.dmg_eweapon += dmg_dealt;
+			}
 		}
 
 		// real hits

--- a/src/match.c
+++ b/src/match.c
@@ -166,7 +166,7 @@ typedef struct teamStats_s {
 	char *name; // team name
 	int gfrags; // frags from ghosts
 	int frags, deaths, tkills;
-	float dmg_t, dmg_g, dmg_team;
+	float dmg_t, dmg_g, dmg_team, dmg_eweapon;
 // { ctf
 	float res, str, rgn, hst;
 	int caps, pickups, returns, f_defends, c_defends;
@@ -214,6 +214,7 @@ void CollectTpStats()
 			tmStats[tmStats_cnt].dmg_t    += p2->ps.dmg_t;
 			tmStats[tmStats_cnt].dmg_g    += p2->ps.dmg_g;
 			tmStats[tmStats_cnt].dmg_team += p2->ps.dmg_team;
+			tmStats[tmStats_cnt].dmg_eweapon += p2->ps.dmg_eweapon;
 
 			for ( i = itNONE; i < itMAX; i++ ) { // summ each field of items
 				tmStats[tmStats_cnt].itm[i].tooks += p2->ps.itm[i].tooks;
@@ -339,14 +340,21 @@ void SummaryTPStats()
 		}
 
 		// rl
-		if ( isTeam() ) // rl stats pointless in other modes?
-			G_bprint(2, "%s: %s:%d %s:%d %s:%d\n", redtext("      RL"),
-					redtext("Took"), tmStats[i].wpn[wpRL].tooks, redtext("Killed"), tmStats[i].wpn[wpRL].ekills,
-					redtext("Dropped"), tmStats[i].wpn[wpRL].drops);
+		G_bprint(2, "%s: %s:%d %s:%d %s:%d\n", redtext("      RL"),
+				redtext("Took"), tmStats[i].wpn[wpRL].tooks, redtext("Killed"), tmStats[i].wpn[wpRL].ekills,
+				redtext("Dropped"), tmStats[i].wpn[wpRL].drops);
 
 		// damage
-		G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),
-					redtext("Tkn"), tmStats[i].dmg_t, redtext("Gvn"), tmStats[i].dmg_g, redtext("Tm"), tmStats[i].dmg_team);
+		if ( deathmatch == 1 )
+		{
+			G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),
+						redtext("Tkn"), tmStats[i].dmg_t, redtext("Gvn"), tmStats[i].dmg_g, redtext("EWep"), tmStats[i].dmg_eweapon, redtext("Tm"), tmStats[i].dmg_team);
+		}
+		else
+		{
+			G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),
+						redtext("Tkn"), tmStats[i].dmg_t, redtext("Gvn"), tmStats[i].dmg_g, redtext("Tm"), tmStats[i].dmg_team);
+		}
 	}
 
 	G_bprint(2, "žžžžžžžžžžžžžžžžžžžžžžžžžžžžžžžžžŸ\n");
@@ -393,7 +401,7 @@ int maxspree, maxspree_q;
 
 void OnePlayerStats(gedict_t *p, int tp)
 {
-	float	dmg_g, dmg_t, dmg_team, dmg_g_rl;
+	float	dmg_g, dmg_t, dmg_team, dmg_eweapon, dmg_g_rl;
 	int   ra, ya, ga;
 	int   mh, d_rl, k_rl, t_rl;
 	int   quad, pent, ring;
@@ -404,6 +412,7 @@ void OnePlayerStats(gedict_t *p, int tp)
 	dmg_g_rl = p->ps.dmg_g_rl;
 	dmg_t = p->ps.dmg_t;
 	dmg_team = p->ps.dmg_team;
+	dmg_eweapon = p->ps.dmg_eweapon;
 	ra    = p->ps.itm[itRA].tooks;
 	ya    = p->ps.itm[itYA].tooks;
 	ga    = p->ps.itm[itGA].tooks;
@@ -510,8 +519,16 @@ void OnePlayerStats(gedict_t *p, int tp)
 				redtext("Took"), t_rl, redtext("Killed"), k_rl, redtext("Dropped"), d_rl);
 
 		// damage
-		G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),
-			redtext("Tkn"), dmg_t, redtext("Gvn"), dmg_g, redtext("Tm"), dmg_team);
+		if ( isTeam() && deathmatch == 1 )
+		{
+			G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),
+				redtext("Tkn"), dmg_t, redtext("Gvn"), dmg_g, redtext("EWep"), dmg_eweapon, redtext("Tm"), dmg_team);
+		}
+		else
+		{
+			G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),
+				redtext("Tkn"), dmg_t, redtext("Gvn"), dmg_g, redtext("Tm"), dmg_team);
+		}
 
 		if ( isDuel() )
 		{


### PR DESCRIPTION
In dmm1 team games (typically 3on3, 4on4) it may be useful to know how much damage you gave to enemies that were holding weapons. So alongside Damage taken / given show given to enemy weapons (enemies holding RL or LG).

This was requested on [qw.nu forums](http://www.quakeworld.nu/forum/topic/6742/102223/another-feature-request#102223).

Per player stats: (certainly useful)

![ewep-per-player](https://cloud.githubusercontent.com/assets/11351/11322459/89f2095c-90a1-11e5-9d0f-71d64b28daa6.png)

Per team stats: (less useful, but might as well include it)

![ewep-team](https://cloud.githubusercontent.com/assets/11351/11322461/99acf910-90a1-11e5-8390-da17a29bb32e.png)
