### PR TITLE
Spruce up demo marker output

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -200,6 +200,12 @@ typedef struct vote_s {
 	float elect_block_till;	// block election for this time
 } vote_t;
 
+// demo marker
+typedef struct demo_marker_s {
+	float time;
+	char markername[64];
+} demo_marker_t;
+
 // cmd flood protection
 
 #define MAX_FP_CMDS (10)

--- a/src/commands.c
+++ b/src/commands.c
@@ -250,7 +250,41 @@ static void dumpent( );
 void ToggleCArena();
 // }
 
-void DemoMark() { stuffcmd( self, "//demomark\n" ); }
+// Save the first 5 demo markers to print at the end.
+demo_marker_t demo_markers[10];
+int demo_markers_count = 10;
+int demo_marker_index = 0;
+
+void ClearDemoMarkers()
+{
+	demo_marker_index = 0;
+}
+
+void DemoMark()
+{
+	stuffcmd( self, "//demomark\n" );
+
+	if ( match_in_progress <= 1 )
+		return;
+
+	// Do not add marker if there was already a marker just a few seconds ago.
+	if ( demo_marker_index > 0 && (g_globalvars.time - demo_markers[demo_marker_index - 1].time) < 5 )
+		return;
+
+	if ( demo_marker_index < demo_markers_count )
+	{
+		demo_markers[demo_marker_index].time = g_globalvars.time;
+		strlcpy(demo_markers[demo_marker_index].markername, getname(self), sizeof(demo_markers[demo_marker_index].markername));
+		demo_marker_index++;
+
+		int total = (int)(g_globalvars.time - match_start_time);
+		G_sprint(self, 2, "Added demo marker: \220%d:%02d\221\n", (total / 60), (total % 60));
+	}
+	else
+	{
+		G_sprint(self, 2, "Demo markers full!\n");
+	}
+}
 
 // CD - commands descriptions
 
@@ -869,7 +903,7 @@ cmd_t cmds[] = {
 	{ "dumpent",     dumpent,                   0    , CF_BOTH | CF_PARAMS, CD_DUMPENT },
 	{ "votecoop",    votecoop,                  0    , CF_PLAYER | CF_MATCHLESS, CD_VOTECOOP },
 	{ "coop_nm_pu",	 ToggleNewCoopNm,           0    , CF_PLAYER | CF_MATCHLESS, CD_COOPNMPU },
-	{ "demomark",	 DemoMark,                  0    , CF_PLAYER, CD_DEMOMARK },
+	{ "demomark",	 DemoMark,                  0    , CF_BOTH, CD_DEMOMARK },
 };
 
 #undef DEF

--- a/src/match.c
+++ b/src/match.c
@@ -28,6 +28,7 @@ void OnePlayerMidairStats();
 void OnePlayerInstagibStats();
 void StartLogs();
 void StopLogs();
+void ClearDemoMarkers();
 
 extern int g_matchstarttime;
 
@@ -781,6 +782,25 @@ void TopStats ( )
 	G_bprint(2, "\nŸ\n");
 }
 
+extern demo_marker_t demo_markers[];
+extern int demo_marker_index;
+
+void ListDemoMarkers()
+{
+	if ( !demo_marker_index )
+		return;
+
+    G_bprint(2, "%s:\nŸ\n", redtext("Demo markers"));
+
+	for (int i = 0; i < demo_marker_index; ++i)
+	{
+		int total = (int)(demo_markers[i].time - match_start_time);
+		G_bprint( 2, "%s: %d:%02d \220%s\221\n", redtext("Time"), (total / 60), (total % 60), demo_markers[i].markername);
+	}
+
+	G_bprint(2, "Ÿ\n");
+}
+
 void TopMidairStats ( )
 {
   gedict_t  *p;
@@ -1388,10 +1408,12 @@ void EndMatch ( float skip_log )
 		}
 
 		if( isTeam() || isCTF() )
-				TeamsStats (); // print basic info like frags for each team
+			TeamsStats (); // print basic info like frags for each team
 
 		if ( (p = find( world, FOFCLSN, "ghost" )) ) // show legend :)
 			G_bprint(2, "\n\x83 - %s player\n\n", redtext("disconnected"));
+
+		ListDemoMarkers();
 
 		lastscore_add(); // save game result somewhere, so we can show it later
 
@@ -1902,6 +1924,8 @@ void StartMatch ()
 	SM_PrepareCA();
 
 	SM_on_MatchStart();
+
+	ClearDemoMarkers();
 
 	StartLogs();
 


### PR DESCRIPTION
When a player adds a demo marker the should see it was added:

![player-mark](https://cloud.githubusercontent.com/assets/11351/11322864/35e2f00c-90b4-11e5-9c68-43fb1ea8a5ae.png)

End Game should list marks and who made them:

![end-game-markers](https://cloud.githubusercontent.com/assets/11351/11322868/56cdff3c-90b4-11e5-8009-8c884e3ec302.png)
