### PR TITLE
Detect Transferred Packs - Packs Not Dropped to Enemy

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -119,8 +119,8 @@ typedef struct player_stats_s {
 	int		ot_h;	 // overtime health
 
 	int		spawn_frags;
-
 	int		handicap;
+	int		transferred_packs;
 
 	// ctf stats
 	int ctf_points; // use frags - this to calculate efficiency for ctf
@@ -395,6 +395,9 @@ typedef struct gedict_s {
 	float	ready;           // if a player is ready or not
 	char	*killer;         // name of player who last killed player
 	char	*victim;         // name of player last killed
+
+	char    *backpack_player_name; // player who dropped the backpack
+	char    backpack_team_name[32 /*MAX_TEAM_NAME*/]; // team associated with the backpack
 
 	struct gedict_s *k_lastspawn;    // NOT_SURE: spot at which player last spawned?
 // { kick mode

--- a/src/items.c
+++ b/src/items.c
@@ -1863,7 +1863,7 @@ PLAYER BACKPACKS
 void BackpackTouch()
 {
 	int		new;
-	gedict_t	*stemp;
+	gedict_t	*stemp, *p;
 	float           acount, new_shells, new_nails, new_rockets, new_cells;
 	char            *new_wp = "";
 	char		*playername;
@@ -2048,6 +2048,20 @@ void BackpackTouch()
 	   )
 		other->s.v.ammo_rockets = 5;
 
+	// detect transferred packs, credit the player who dropped the pack with the transfer
+	if ( isTeam() && self->s.v.items == IT_ROCKET_LAUNCHER )
+	{
+		if ( streq(self->backpack_team_name, getteam(other)) )
+		{
+			for( p = world; (p = find_plr( p )); ) {
+				if ( streq(getname(p), self->backpack_player_name) ) {
+					p->ps.transferred_packs++;
+					break;
+				}
+			}
+		}
+	}
+
 	G_sprint( other, PRINT_LOW, "\n" );
 // backpack touch sound
 	sound( other, CHAN_ITEM, "weapons/lock4.wav", 1, ATTN_NORM );
@@ -2230,6 +2244,12 @@ void DropBackpack()
 	item->s.v.think = ( func_t ) SUB_Remove;
 
 	item->s.v.classname = "backpack"; // we do need to be able to get rid of these things between points (hoony mode)
+
+	if (isTeam())
+	{
+		item->backpack_player_name = playername;
+		strlcpy(item->backpack_team_name, getteam(self), MAX_TEAM_NAME);
+	}
 }
 
 /*

--- a/src/match.c
+++ b/src/match.c
@@ -173,6 +173,7 @@ typedef struct teamStats_s {
 // }
 	wpType_t wpn[wpMAX];
 	itType_t itm[itMAX];
+	int transferred_packs;
 } teamStats_t;
 
 teamStats_t tmStats[MAX_TM_STATS];
@@ -232,6 +233,8 @@ void CollectTpStats()
 				tmStats[tmStats_cnt].wpn[i].tooks   += p2->ps.wpn[i].tooks;
 				tmStats[tmStats_cnt].wpn[i].ttooks  += p2->ps.wpn[i].ttooks;
 			}
+
+			tmStats[tmStats_cnt].transferred_packs += p2->ps.transferred_packs;
 
 // { ctf related
 			tmStats[tmStats_cnt].res += p2->ps.res_time;
@@ -339,10 +342,9 @@ void SummaryTPStats()
 		}
 
 		// rl
-		if ( isTeam() ) // rl stats pointless in other modes?
-			G_bprint(2, "%s: %s:%d %s:%d %s:%d\n", redtext("      RL"),
-					redtext("Took"), tmStats[i].wpn[wpRL].tooks, redtext("Killed"), tmStats[i].wpn[wpRL].ekills,
-					redtext("Dropped"), tmStats[i].wpn[wpRL].drops);
+		G_bprint(2, "%s: %s:%d %s:%d %s:%d %s:%d\n", redtext("      RL"),
+				redtext("Took"), tmStats[i].wpn[wpRL].tooks, redtext("Killed"), tmStats[i].wpn[wpRL].ekills,
+				redtext("Dropped"), tmStats[i].wpn[wpRL].drops, redtext("Xfer"), tmStats[i].transferred_packs);
 
 		// damage
 		G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),
@@ -506,8 +508,9 @@ void OnePlayerStats(gedict_t *p, int tp)
 
 		// rl
 		if ( isTeam() )
-			G_bprint(2, "%s: %s:%d %s:%d %s:%d\n", redtext("      RL"),
-				redtext("Took"), t_rl, redtext("Killed"), k_rl, redtext("Dropped"), d_rl);
+			G_bprint(2, "%s: %s:%d %s:%d %s:%d%s\n", redtext("      RL"),
+				redtext("Took"), t_rl, redtext("Killed"), k_rl, redtext("Dropped"), d_rl,
+				(p->ps.transferred_packs ? va(" %s:%d", redtext("Xfer"), p->ps.transferred_packs) : ""));
 
 		// damage
 		G_bprint(2, "%s: %s:%.0f %s:%.0f %s:%.0f\n", redtext("  Damage"),


### PR DESCRIPTION
Detect and log Transferred packs in the end game stats. When a pack drops, record the dropping player / team. When the pack is picked up, if it was within the same team, credit the original player with a transferred pack. Show transferred packs in end game stats if non-zero.

I wasn't sure how best to handle player name / team name nonsense. It seems there are like a dozen different ways to do this and most are unsafe. I copied the team name since getteam() doesn't seem to return a safe value. I use the player's netname since that seems like a pointer unlikely to change. Review comments appreciated.

End game player stats: (shows non-zero Xfers)

![player-xfer-pack](https://cloud.githubusercontent.com/assets/11351/11323310/b23b31ea-90c4-11e5-9235-8cbbdc956822.png)

End game team stats: (always shows Xfers)

![team-xfer-packs](https://cloud.githubusercontent.com/assets/11351/11323312/b75eb4ee-90c4-11e5-876d-a5315dbb337e.png)

Tested: Player dropped to themselves, player dropping to teammate, player dropping to enemy, player dropping and pack not getting picked up.
Did not test: Player changing name mid-game.