### PR TITLE
ENTITY FILES: Support multiple .ent files for each map.

### DIFF
--- a/include/g_local.h
+++ b/include/g_local.h
@@ -978,3 +978,5 @@ void swimmonster_start( char *model );
 
 void LaunchLaser( vec3_t org, vec3_t vec );
 
+// identify alternative .ent files by format <map>#<name>.ent
+#define SV_ENTITYFILE_SEPARATOR '#'

--- a/src/client.c
+++ b/src/client.c
@@ -482,7 +482,12 @@ void GotoNextMap()
 	if ( trap_cvar( "samelevel" ) )
 	{
 		// if samelevel is set, stay on same level
-		strlcpy( newmap, g_globalvars.mapname, sizeof(newmap) );
+		char *entityfile = cvar_string("sv_entityfile");
+
+		if (! strnull(entityfile))
+			strlcpy( newmap, entityfile, sizeof(newmap) );
+		else
+			strlcpy( newmap, g_globalvars.mapname, sizeof(newmap) );
 	}
 	else
 	{
@@ -666,6 +671,7 @@ go to the next level for deathmatch
 void NextLevel()
 {
 	gedict_t       *o;
+	char           *entityfile;
 
 	if ( k_bloodfest )
 		return;
@@ -673,7 +679,11 @@ void NextLevel()
 	if ( nextmap[0] )
 		return;		// already done
 
-	set_nextmap( g_globalvars.mapname );
+	entityfile = cvar_string("sv_entityfile");
+	if (! strnull(entityfile))
+		set_nextmap( entityfile );
+	else
+		set_nextmap( g_globalvars.mapname );
 
 	o = spawn();
 	o->map = g_globalvars.mapname;

--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -1399,13 +1399,28 @@ qbool SetHandicap( gedict_t *p, int nhdc )
 
 void changelevel( const char *name )
 {
+	char* entityFileSep = NULL;
+
  	if ( strnull( name ) )
 		G_Error("changelevel: null");
 
 	if ( isRACE() && race.race_recording )
 		race_stoprecord( true );
 
-	trap_changelevel(name);
+	entityFileSep = strchr(name, SV_ENTITYFILE_SEPARATOR);
+	if (entityFileSep)
+	{
+		char mapName[128] = { 0 };
+
+		cvar_set("sv_entityfile", name);
+		strlcpy(mapName, (char*)name, min(entityFileSep - name + 1, sizeof(mapName) / sizeof(mapName[0])));
+		trap_changelevel(mapName);
+	}
+	else
+	{
+		cvar_set("sv_entityfile", "");
+		trap_changelevel(name);
+	}
 }
 
 char *Get_PowerupsStr(void)


### PR DESCRIPTION
Any .ent files in the maps or entfiles directories which are in format mapName#xxx.ent
will be added to the maps list.  If selected, sv_entityfile will be set to the name of
the entity file, and the map changed to mapName.

Requires server support for sv_entityfile cvar.