### PR TITLE
SP_MONSTERS: only use is_location_occupied in bloodfest mode

### DIFF
--- a/src/sp_monsters.c
+++ b/src/sp_monsters.c
@@ -812,20 +812,18 @@ void monster_start_go( monsterType_t mt )
 	self->s.v.solid = SOLID_SLIDEBOX;
 	self->s.v.takedamage = DAMAGE_AIM;
 
-	if ( /*!walkmove( self, 0, 0 )*/
-			is_location_occupied( self, self->s.v.origin, self->s.v.mins, self->s.v.maxs )
-	)
+	if (k_bloodfest && is_location_occupied( self, self->s.v.origin, self->s.v.mins, self->s.v.maxs ))
 	{
-		if ( k_bloodfest )
-		{
-//			G_cprint( "monster (%s) in wall at: %.1f %.1f %.1f, removed!\n",
-//				self->s.v.classname, self->s.v.origin[0], self->s.v.origin[1], self->s.v.origin[2] );
+//		G_cprint( "monster (%s) in wall at: %.1f %.1f %.1f, removed!\n",
+//			self->s.v.classname, self->s.v.origin[0], self->s.v.origin[1], self->s.v.origin[2] );
 
-			ent_remove( self ); // remove it ASAP.
-			return;
-		}
+		ent_remove( self ); // remove it ASAP.
+		return;
+	}
 
-		G_cprint( "monster in wall at: %.1f %.1f %.1f\n", self->s.v.origin[0], self->s.v.origin[1], self->s.v.origin[2] );
+	if (!k_bloodfest && !walkmove(self, 0, 0))
+	{
+		G_cprint( "monster %d in wall at: %.1f %.1f %.1f\n", NUM_FOR_EDICT(self), self->s.v.origin[0], self->s.v.origin[1], self->s.v.origin[2] );
 
 		self->s.v.model = ""; // turn off model
 		self->s.v.solid = SOLID_NOT;


### PR DESCRIPTION
Some wizards which spawn right next to walls/ceilings to be in constant
state of waiting five seconds before trying to spawn again... but during
this time they see player, nextthink is changed accordingly, and the
player is attacked by a wizard that they cannot see or hit.

(example is e1m2 in the secret to the right hand side of the start)