### PR TITLE
RACE: Allow race routes to be defined by map entities

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -614,6 +614,15 @@ typedef struct gedict_s {
 	qbool		racer;				// this player do race right now
 	qbool		muted;				// this player produces no sound
 	int			hideentity;			// links to entity to hide in eye chasecam
+
+	// race_route_start entity fields
+	char*       race_route_name;            // the name of the route
+	char*       race_route_description;     // the description of the route
+	int         race_route_timeout;         // the maximum time to complete the route
+	int         race_route_weapon_mode;     // the weapon mode - see raceWeapoMode_t
+	int         race_route_falsestart_mode; // the falsestart mode - see raceFalseStartMode_t
+	float       race_route_start_yaw;       // the player's initial yaw angle
+	float       race_route_start_pitch;     // the player's initial pitch angle
 // }
 
 	int			trackent;			// pseudo spectating for players.

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -122,6 +122,13 @@ field_t         fields[] = {
 	{"team_no",	FOFS( team_no ),		F_INT},
 // custom teleporters
 	{"size", 	FOFS( s.v.size ),	F_VECTOR},
+	{"race_route_name", FOFS( race_route_name ), F_LSTRING},
+	{"race_route_description", FOFS( race_route_description ), F_LSTRING},
+	{"race_route_timeout", FOFS( race_route_timeout ), F_INT},
+	{"race_route_weapon_mode", FOFS( race_route_weapon_mode ), F_INT},
+	{"race_route_falsestart_mode", FOFS( race_route_falsestart_mode ), F_INT},
+	{"race_route_start_yaw", FOFS( race_route_start_yaw ), F_FLOAT},
+	{"race_route_start_pitch", FOFS( race_route_start_yaw ), F_FLOAT},
 	{NULL}
 };
 typedef struct {
@@ -260,6 +267,9 @@ void			SP_item_tfgoal();
 void			SP_info_player_teamspawn();
 void			SP_i_p_t();
 
+// Races
+void            SP_race_route_start();
+
 spawn_t         spawns[] = {
 	// info entities don't do anything at all, but provide positional
 	// information for things controlled by other processes
@@ -391,6 +401,10 @@ Used as a positional target for spotlights, etc.
 	{"event_lightning",		SP_event_lightning},
 
 	{"info_monster_start",	SP_info_monster_start},
+
+	// race routes
+	{"race_route_start",    SP_race_route_start},
+	{"race_route_marker",   SUB_Null},
 
 	{0, 0}
 };


### PR DESCRIPTION
This is to so KTX doesn't need to be updated whenever a new race map
is created.

Two new entity types:
  race_route_start
  race_route_marker

race_route_start requires the following properties:
  origin (vector)
  race_route_name (string)
  race_route_description (string)
  race_route_timeout (int)
  race_route_weapon_mode (enum - matches KTX raceWeapoMode_t)
  race_route_falsestart_mode (enum - matches KTX raceFalseStartMode_t)
  target (string, must point to corresponding race_route_marker)

race_route_marker requires:
  origin (vector)
  targetname (string)

Each entity links to next marker through target attribute, the last marker
in the sequence is considered the end of the route.