### PR TITLE
ENTITY FILES: Support multiple .ent files for each map.

### DIFF
--- a/include/g_local.h
+++ b/include/g_local.h
@@ -978,3 +978,5 @@ void swimmonster_start( char *model );
 
 void LaunchLaser( vec3_t org, vec3_t vec );
 
+// identify alternative .ent files by format <map>#<name>.ent
+#define K_ENTITYFILE_SEPARATOR '#'

--- a/include/g_syscalls.h
+++ b/include/g_syscalls.h
@@ -80,7 +80,7 @@ gedict_t*	trap_findradius( gedict_t* ent, float *org, float rad );
 
 void    trap_makestatic( intptr_t edn );
 void    trap_setspawnparam( intptr_t edn );
-void    trap_changelevel( const char *name );
+void    trap_changelevel( const char *name, const char* entityname );
 intptr_t     trap_multicast( float origin_x, float origin_y, float origin_z, intptr_t to );
 void    trap_logfrag( intptr_t killer, intptr_t killee );
 void    trap_infokey( intptr_t edn, char *key, char *valbuff, intptr_t sizebuff );

--- a/src/client.c
+++ b/src/client.c
@@ -482,7 +482,12 @@ void GotoNextMap()
 	if ( trap_cvar( "samelevel" ) )
 	{
 		// if samelevel is set, stay on same level
-		strlcpy( newmap, g_globalvars.mapname, sizeof(newmap) );
+		char *entityfile = cvar_string("k_entityfile");
+
+		if (! strnull(entityfile))
+			strlcpy( newmap, entityfile, sizeof(newmap) );
+		else
+			strlcpy( newmap, g_globalvars.mapname, sizeof(newmap) );
 	}
 	else
 	{
@@ -666,6 +671,7 @@ go to the next level for deathmatch
 void NextLevel()
 {
 	gedict_t       *o;
+	char           *entityfile;
 
 	if ( k_bloodfest )
 		return;
@@ -673,7 +679,11 @@ void NextLevel()
 	if ( nextmap[0] )
 		return;		// already done
 
-	set_nextmap( g_globalvars.mapname );
+	entityfile = cvar_string("k_entityfile");
+	if (! strnull(entityfile))
+		set_nextmap( entityfile );
+	else
+		set_nextmap( g_globalvars.mapname );
 
 	o = spawn();
 	o->map = g_globalvars.mapname;

--- a/src/g_syscalls.c
+++ b/src/g_syscalls.c
@@ -274,9 +274,9 @@ void trap_setspawnparam( intptr_t edn )
 	syscall( G_SETSPAWNPARAMS, edn );
 }
 
-void trap_changelevel( const char *name )
+void trap_changelevel( const char *name, const char* entityname )
 {
-	syscall( G_CHANGELEVEL, name );
+	syscall( G_CHANGELEVEL, name, entityname );
 }
 
 intptr_t trap_multicast( float origin_x, float origin_y, float origin_z, intptr_t to )

--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -1399,13 +1399,28 @@ qbool SetHandicap( gedict_t *p, int nhdc )
 
 void changelevel( const char *name )
 {
+	const char* entityFileSep = NULL;
+
  	if ( strnull( name ) )
 		G_Error("changelevel: null");
 
 	if ( isRACE() && race.race_recording )
 		race_stoprecord( true );
 
-	trap_changelevel(name);
+	entityFileSep = strchr(name, K_ENTITYFILE_SEPARATOR);
+	if (entityFileSep)
+	{
+		char mapName[128] = { 0 };
+
+		cvar_set("k_entityfile", name);
+		strlcpy(mapName, (char*)name, min(entityFileSep - name + 1, sizeof(mapName) / sizeof(mapName[0])));
+		trap_changelevel(mapName, name);
+	}
+	else
+	{
+		cvar_set("k_entityfile", "");
+		trap_changelevel(name, "");
+	}
 }
 
 char *Get_PowerupsStr(void)

--- a/src/maps.c
+++ b/src/maps.c
@@ -101,6 +101,80 @@ static void Map_AddMapToList( char *name )
 	maps_cnt++;
 }
 
+// Extension to allow multiple .ent files for individual maps.
+// We check all *.ent files we can find, and look for format mapName#description.ent, where mapName is a 
+//    standard map we already have in list.
+void GetCustomEntityMapsForDirectory(char* directory)
+{
+	char *s, name[32], *sep;
+	int i, cnt, l, m;
+
+	ml_buf[0] = 0;
+
+	// Find all entity files in the maps directory
+	cnt = trap_FS_GetFileList( directory, ( FTE_sv ? ".ent" : "\\.ent$" ), ml_buf, sizeof(ml_buf), 0 );
+	ml_buf[sizeof(ml_buf)-1] = 0;
+
+	for ( i = 0, s = ml_buf; i < cnt && s < ml_buf + sizeof(ml_buf); ++i )
+	{
+		l = strlen( s );
+
+		if ( FTE_sv )
+			l -= 4; // skip extension
+
+		if ( l <= 0 )
+			break;
+
+		l++; // + nul
+
+		sep = strchr(s, K_ENTITYFILE_SEPARATOR);
+		if (sep)
+		{
+			int baseMapFound = 0, duplicateFound = 0;
+			int mapNameLength;
+
+			// copy
+			strlcpy( name, s, min( sizeof(name), l ) );
+
+			// The server could have mapName#entName.ent in more than one directory, so check here for duplicates
+			mapNameLength = sep - s;
+			if (mapNameLength > 0)
+			{
+				for (m = 0; m < maps_cnt; ++m)
+				{
+					baseMapFound |= (strlen(mapslist[m]) == mapNameLength && !strncmp(mapslist[m], s, mapNameLength));
+					duplicateFound |= !strcmp(mapslist[m], s);
+				}
+
+				if (baseMapFound && ! duplicateFound)
+					Map_AddMapToList( name );
+			}
+		}
+
+		// find next map name
+		s = strchr(s, 0);
+		if ( !s )
+			G_Error( "GetMapList: strchr returns NULL" );
+		s++;
+	}
+
+	return;
+}
+
+void GetCustomEntityMaps(void)
+{
+	char path[1024] = { 0 };
+
+	char* entityDir = cvar_string("sv_loadentfiles_dir");
+	if (entityDir && *entityDir)
+	{
+		snprintf(path, sizeof(path) - 1, "maps/%s", entityDir);
+		GetCustomEntityMapsForDirectory(path);
+	}
+
+	GetCustomEntityMapsForDirectory("maps");
+}
+
 void AddFixedMaps(void)
 {
 	int i;
@@ -155,6 +229,8 @@ void GetMapList(void)
 
 		s++;
 	}
+
+	GetCustomEntityMaps();
 
 #if 0 // debug
 	G_cprint( "Maps list\n" );

--- a/src/world.c
+++ b/src/world.c
@@ -735,6 +735,7 @@ void FirstFrame	( )
 	RegisterCvarEx("k_spm_show", "1");
 	RegisterCvarEx("k_spm_glow", "0");
 	RegisterCvarEx("k_spm_custom_model", "0");
+	RegisterCvar("k_entityfile");
 // { hoonymode
 	RegisterCvarEx("k_hoonymode", "0");
 // }


### PR DESCRIPTION
Any .ent files in the maps or entfiles directories which are in format
mapName#xxx.ent will be added to the maps list.  If selected, uses extended
map command in mvdsv (map <mapname> <entfile>) to switch.

Requires server support for updated map command.