### PR TITLE
RACE: Prevent remote crash through race_show_record_details

### DIFF
--- a/src/race.c
+++ b/src/race.c
@@ -2073,7 +2073,7 @@ void display_record_details( )
 	if ( record )
 		record = 1;
 
-	record = bound(0, atoi( arg_1 ) - 1, NUM_BESTSCORES );
+	record = bound(0, atoi( arg_1 ) - 1, NUM_BESTSCORES - 1 );
 
 	if ( race.records[record].time > 999998 )
 	{


### PR DESCRIPTION
Bounds check leads to off by one error, then race_weapon_mode() calls G_Error
(command only available when /race enabled)
