### PR TITLE
amphi2 bots causes NULL pointer dereference in HasWeapon

### DIFF
--- a/src/fb_globals.c
+++ b/src/fb_globals.c
@@ -183,9 +183,9 @@ qbool HasWeapon(gedict_t* player, int weapon)
 	return ((int)player->s.v.items & weapon);
 }
 
-float enemy_shaft_attack(void)
+float enemy_shaft_attack(gedict_t* self, gedict_t* enemy)
 {
-	return (HasWeapon(enemy_, IT_LIGHTNING) && enemy_->s.v.ammo_cells && (self->fb.enemy_dist < 630) && (g_globalvars.time < enemy_->attack_finished));
+	return (HasWeapon(enemy, IT_LIGHTNING) && enemy->s.v.ammo_cells && (self->fb.enemy_dist < 630) && (g_globalvars.time < enemy->attack_finished));
 }
 
 qbool bots_enabled(void)

--- a/src/fb_globals.h
+++ b/src/fb_globals.h
@@ -168,7 +168,7 @@ float boomstick_only (void);
 float CountTeams (void);
 qbool EnemyDefenceless (gedict_t* self);
 
-float enemy_shaft_attack (void);
+float enemy_shaft_attack (gedict_t* self, gedict_t* enemy);
 float W_BestWeapon (void);
 
 gedict_t* LocateMarker (vec3_t org);

--- a/src/maps_map_amphi2.c
+++ b/src/maps_map_amphi2.c
@@ -6,6 +6,8 @@
 #include "fb_globals.h"
 
 void AMPHI2BotInLava(void) {
+	gedict_t* enemy = &g_edicts[self->s.v.enemy];
+
 	// TODO: rewrite... essentially if in lava and enemy isn't shafting, jump to target instead of walk
 	//       this is probably true of all lava-burn situations, as long as we're not lava-rjing to escape?
 	if ( self->isBot && streq(g_globalvars.mapname, "amphi2") ) {
@@ -17,7 +19,7 @@ void AMPHI2BotInLava(void) {
 
 				if (trap_pointcontents(PASSVEC3(point)) == CONTENT_LAVA) {
 					if ((int)self->s.v.flags & FL_ONGROUND) {
-						if (!enemy_shaft_attack()) {
+						if (!enemy_shaft_attack(self, enemy)) {
 							if (!self->fb.rocketJumping) {
 								NewVelocityForArrow (self, self->fb.dir_move_, "amphi2");
 								SetJumpFlag (self, true, "AMPHI2 logic");


### PR DESCRIPTION
Using a local mvdsv/ktx setup (Linux x86_64) I ran into a crash.
1. Add bot on map amphi2
2. Push bot into lava
3. `AMPHI2BotInLava` => `enemy_shaft_attack` => `HasWeapon(NULL, IT_LIGHTNING)` => mvdsv segfaults

`#0  HasWeapon (player=0x0, weapon=weapon@entry=64) at fb_globals.c:183`
`183             return ((int)player->s.v.items & weapon);`

`enemy_shaft_attack` uses the global `enemy_` which is never set.

As far as I can tell `enemy_shaft_attack` is only called by `AMPHI2BotInLava`, so I changed it to take `(self, enemy)` arguments rather than figure out when, where and how to set `enemy_`. (`s/enemy_/enemy/` inside it to avoid any reader scope confusion.) No crashes since, so it seems to me that `g_edicts` is sufficiently reliable.

Adding `if (!player) return 0;` to `HasWeapon` also prevents the crash but makes `enemy_shaft_attack` fail silently and always return 0.

@meag I feel you should be specifically mentioned since this is your code I am messing with without fully knowing it.