### PR TITLE
MESON: add meson_options.txt

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -102,9 +102,14 @@ ktx_sources = [
 	'src/world.c',
 ]
 
+c_args = []
+if get_option('bot_support')
+	c_args = '-DBOT_SUPPORT=1'
+endif
+
 library('qwprogs', ktx_sources,
 	include_directories : include_directories('include'),
-	c_args : '-DBOT_SUPPORT=1',
+	c_args : c_args,
 	dependencies : [
 		meson.get_compiler('c').find_library('m', required : false)
 	],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('bot_support', type : 'boolean', value : true)


### PR DESCRIPTION
You can now enable/disable bot support via the "bot_support" option. It is enabled by default.