### PR TITLE
CTF: Runes power settings

### DIFF
--- a/resources/example-configs/ktx/ktx.cfg
+++ b/resources/example-configs/ktx/ktx.cfg
@@ -62,6 +62,10 @@ set k_allowed_free_modes      255       // allowed free modes (bit mask):
 
 // ctf
 set k_ctf_custom_models       1         // ctf models (0 = use original quake models, 1 = use ctf models)
+set k_ctf_rune_power_str      2.0       // strength rune power (default is 2)
+set k_ctf_rune_power_res      2.0       // resistance rune power (default is 2)
+set k_ctf_rune_power_rgn      2.0       // regeneration rune power (default is 2)
+set k_ctf_rune_power_hst      2.0       // haste rune power (default is 2)
 
 // prewar
 set k_prewar                  1         // prewar setting (0 = prewar fire is disallowed, 1 = prewar fire is allowed, 2 = no fire or jump until ready)

--- a/src/bot_aim.c
+++ b/src/bot_aim.c
@@ -160,7 +160,7 @@ static void BotsAimAtPlayerLogic(gedict_t* self, vec3_t rel_pos, float* rel_dist
 	if (IsVelocityWeapon(self->fb.desired_weapon_impulse) && !AttackFinished(self)) {
 		rel_time = *rel_dist / 1000;
 		if (IsNailgun(self->fb.desired_weapon_impulse) && (self->ctf_flag & CTF_RUNE_HST)) {
-			rel_time *= 0.5;
+			rel_time /= min(cvar("k_ctf_rune_power_hst"), 1.0);
 		}
 		else if (self->fb.desired_weapon_impulse == 6) {
 			rel_time = *rel_dist / 600;

--- a/src/bot_aim.c
+++ b/src/bot_aim.c
@@ -160,7 +160,7 @@ static void BotsAimAtPlayerLogic(gedict_t* self, vec3_t rel_pos, float* rel_dist
 	if (IsVelocityWeapon(self->fb.desired_weapon_impulse) && !AttackFinished(self)) {
 		rel_time = *rel_dist / 1000;
 		if (IsNailgun(self->fb.desired_weapon_impulse) && (self->ctf_flag & CTF_RUNE_HST)) {
-			rel_time /= min(cvar("k_ctf_rune_power_hst"), 1.0);
+			rel_time /= (cvar("k_ctf_rune_power_hst") / 2) + 1;
 		}
 		else if (self->fb.desired_weapon_impulse == 6) {
 			rel_time = *rel_dist / 600;

--- a/src/bot_botstat.c
+++ b/src/bot_botstat.c
@@ -82,7 +82,7 @@ void FrogbotSetHealthArmour(gedict_t* client)
 	}
 
 	if ((int)client->ctf_flag & CTF_RUNE_RES) {
-		client->fb.total_damage *= min(cvar("k_ctf_rune_power_res"), 1.0);
+		client->fb.total_damage *= (cvar("k_ctf_rune_power_res") / 2) + 1;
 	}
 }
 
@@ -187,7 +187,7 @@ void FrogbotSetFirepower(gedict_t* self)
 		firepower_ *= (deathmatch == 4 ? 8 : 4);
 	}
 	if (self->ctf_flag & CTF_RUNE_STR) {
-		firepower_ *= min(cvar("k_ctf_rune_power_str"), 1.0);
+		firepower_ *= (cvar("k_ctf_rune_power_str") / 2) + 1;
 	}
 	self->fb.firepower = firepower_;
 }

--- a/src/bot_botstat.c
+++ b/src/bot_botstat.c
@@ -82,7 +82,7 @@ void FrogbotSetHealthArmour(gedict_t* client)
 	}
 
 	if ((int)client->ctf_flag & CTF_RUNE_RES) {
-		client->fb.total_damage *= 2;
+		client->fb.total_damage *= min(cvar("k_ctf_rune_power_res"), 1.0);
 	}
 }
 
@@ -187,7 +187,7 @@ void FrogbotSetFirepower(gedict_t* self)
 		firepower_ *= (deathmatch == 4 ? 8 : 4);
 	}
 	if (self->ctf_flag & CTF_RUNE_STR) {
-		firepower_ *= 2;
+		firepower_ *= min(cvar("k_ctf_rune_power_str"), 1.0);
 	}
 	self->fb.firepower = firepower_;
 }

--- a/src/bot_botweap.c
+++ b/src/bot_botweap.c
@@ -60,10 +60,10 @@ static qbool RocketSafe(void) {
 		splash_damage = splash_damage * (deathmatch != 4 ? 4 : 8);
 		if (self->ctf_flag & ITEM_RUNE_MASK) {
 			if (self->ctf_flag & CTF_RUNE_STR) {
-				splash_damage = splash_damage * min(cvar("k_ctf_rune_power_str"), 1.0);
+				splash_damage = splash_damage * (cvar("k_ctf_rune_power_str") / 2) + 1;
 			}
 			else if (self->ctf_flag & CTF_RUNE_RES) {
-				splash_damage = splash_damage / min(cvar("k_ctf_rune_power_res"), 1.0);
+				splash_damage = splash_damage / (cvar("k_ctf_rune_power_res") / 2) + 1;
 			}
 		}
 	}

--- a/src/bot_botweap.c
+++ b/src/bot_botweap.c
@@ -60,10 +60,10 @@ static qbool RocketSafe(void) {
 		splash_damage = splash_damage * (deathmatch != 4 ? 4 : 8);
 		if (self->ctf_flag & ITEM_RUNE_MASK) {
 			if (self->ctf_flag & CTF_RUNE_STR) {
-				splash_damage = splash_damage * 2;
+				splash_damage = splash_damage * min(cvar("k_ctf_rune_power_str"), 1.0);
 			}
 			else if (self->ctf_flag & CTF_RUNE_RES) {
-				splash_damage = splash_damage * 0.5;
+				splash_damage = splash_damage / min(cvar("k_ctf_rune_power_res"), 1.0);
 			}
 		}
 	}

--- a/src/client.c
+++ b/src/client.c
@@ -2926,7 +2926,7 @@ void PlayerPreThink()
 				self->s.v.health += 5;
 				if ( self->s.v.health > 150 )
 					self->s.v.health = 150;
-				self->regen_time += (1 / min(cvar("k_ctf_rune_power_rgn"), 1.0));
+				self->regen_time += 1 / ((cvar("k_ctf_rune_power_rgn") / 2) + 1);
 #ifdef BOT_SUPPORT
 				FrogbotSetHealthArmour (self);
 #endif

--- a/src/client.c
+++ b/src/client.c
@@ -2926,7 +2926,7 @@ void PlayerPreThink()
 				self->s.v.health += 5;
 				if ( self->s.v.health > 150 )
 					self->s.v.health = 150;
-				self->regen_time += 0.5;
+				self->regen_time += (1 / min(cvar("k_ctf_rune_power_rgn"), 1.0));
 #ifdef BOT_SUPPORT
 				FrogbotSetHealthArmour (self);
 #endif

--- a/src/combat.c
+++ b/src/combat.c
@@ -444,12 +444,12 @@ void T_Damage( gedict_t * targ, gedict_t * inflictor, gedict_t * attacker, float
 
 	// ctf strength rune
 	if ( attacker->ctf_flag & CTF_RUNE_STR )
-		damage *= (cvar("k_ctf_rune_power_str") / 4) + 1;
+		damage *= (cvar("k_ctf_rune_power_str") / 2) + 1;
 
 	// ctf resistance rune
 	if ( targ->ctf_flag & CTF_RUNE_RES )
 	{
-		damage /= (cvar("k_ctf_rune_power_res") / 4) + 1;
+		damage /= (cvar("k_ctf_rune_power_res") / 2) + 1;
 		ResistanceSound( targ );
 	}
 

--- a/src/combat.c
+++ b/src/combat.c
@@ -444,12 +444,12 @@ void T_Damage( gedict_t * targ, gedict_t * inflictor, gedict_t * attacker, float
 
 	// ctf strength rune
 	if ( attacker->ctf_flag & CTF_RUNE_STR )
-		damage *= min(cvar("k_ctf_rune_power_str"), 1.0);
+		damage *= (cvar("k_ctf_rune_power_str") / 4) + 1;
 
 	// ctf resistance rune
 	if ( targ->ctf_flag & CTF_RUNE_RES )
 	{
-		damage /= min(cvar("k_ctf_rune_power_res"), 1.0);
+		damage /= (cvar("k_ctf_rune_power_res") / 4) + 1;
 		ResistanceSound( targ );
 	}
 

--- a/src/combat.c
+++ b/src/combat.c
@@ -444,12 +444,12 @@ void T_Damage( gedict_t * targ, gedict_t * inflictor, gedict_t * attacker, float
 
 	// ctf strength rune
 	if ( attacker->ctf_flag & CTF_RUNE_STR )
-		damage *= 1.5;
+		damage *= min(cvar("k_ctf_rune_power_str"), 1.0);
 
 	// ctf resistance rune
 	if ( targ->ctf_flag & CTF_RUNE_RES )
 	{
-		damage /= 1.5;
+		damage /= min(cvar("k_ctf_rune_power_res"), 1.0);
 		ResistanceSound( targ );
 	}
 

--- a/src/grapple.c
+++ b/src/grapple.c
@@ -303,7 +303,7 @@ void GrappleService()
 	VectorNormalize( hookVelocity );
 
 	if ( self->ctf_flag & CTF_RUNE_HST )
-		VectorScale( hookVelocity, 800 + (100 * ((cvar("k_ctf_rune_power_hst") / 2) + 1), self->s.v.velocity );
+		VectorScale( hookVelocity, 800 + (100 * (cvar("k_ctf_rune_power_hst") / 2 + 1)), self->s.v.velocity );
 	else
 		VectorScale( hookVelocity, 800, self->s.v.velocity );
  
@@ -353,7 +353,7 @@ void GrappleThrow()
 	// Removing purectf velocity changes ( 2.5 * self->maxspeed )
 
 	if ( self->ctf_flag & CTF_RUNE_HST )
-		VectorScale( g_globalvars.v_forward, 800 +(100 * ((cvar("k_ctf_rune_power_hst") / 2) + 1), newmis->s.v.velocity );
+		VectorScale( g_globalvars.v_forward, 800 + (100 * (cvar("k_ctf_rune_power_hst") / 2 + 1)), newmis->s.v.velocity );
 	else
 		VectorScale( g_globalvars.v_forward, 800, newmis->s.v.velocity );
 	SetVector( newmis->s.v.avelocity, 0, 0, -500 );

--- a/src/grapple.c
+++ b/src/grapple.c
@@ -303,7 +303,7 @@ void GrappleService()
 	VectorNormalize( hookVelocity );
 
 	if ( self->ctf_flag & CTF_RUNE_HST )
-		VectorScale( hookVelocity, 1000, self->s.v.velocity );
+		VectorScale( hookVelocity, 800 + (100 * min(cvar("k_ctf_rune_power_hst"), 1.0)), self->s.v.velocity );
 	else
 		VectorScale( hookVelocity, 800, self->s.v.velocity );
  
@@ -353,7 +353,7 @@ void GrappleThrow()
 	// Removing purectf velocity changes ( 2.5 * self->maxspeed )
 
 	if ( self->ctf_flag & CTF_RUNE_HST )
-		VectorScale( g_globalvars.v_forward, 1000, newmis->s.v.velocity );
+		VectorScale( g_globalvars.v_forward, 800 + (100 * min(cvar("k_ctf_rune_power_hst"), 1.0)), newmis->s.v.velocity );
 	else
 		VectorScale( g_globalvars.v_forward, 800, newmis->s.v.velocity );
 	SetVector( newmis->s.v.avelocity, 0, 0, -500 );
@@ -399,7 +399,7 @@ void UnfreezeGravity( gedict_t *p )
 	p->maxspeed = cvar("sv_maxspeed");
 
 	if ( p->ctf_flag & CTF_RUNE_HST )
-		p->maxspeed *= 1.25;
+		p->maxspeed *= min(cvar("k_ctf_rune_power_hst"), 1.0);
 
 	p->gravity = 1;
 	p->ctf_freeze = 0;

--- a/src/grapple.c
+++ b/src/grapple.c
@@ -303,7 +303,7 @@ void GrappleService()
 	VectorNormalize( hookVelocity );
 
 	if ( self->ctf_flag & CTF_RUNE_HST )
-		VectorScale( hookVelocity, 800 + (100 * min(cvar("k_ctf_rune_power_hst"), 1.0)), self->s.v.velocity );
+		VectorScale( hookVelocity, 800 + (100 * ((cvar("k_ctf_rune_power_hst") / 2) + 1), self->s.v.velocity );
 	else
 		VectorScale( hookVelocity, 800, self->s.v.velocity );
  
@@ -353,7 +353,7 @@ void GrappleThrow()
 	// Removing purectf velocity changes ( 2.5 * self->maxspeed )
 
 	if ( self->ctf_flag & CTF_RUNE_HST )
-		VectorScale( g_globalvars.v_forward, 800 + (100 * min(cvar("k_ctf_rune_power_hst"), 1.0)), newmis->s.v.velocity );
+		VectorScale( g_globalvars.v_forward, 800 +(100 * ((cvar("k_ctf_rune_power_hst") / 2) + 1), newmis->s.v.velocity );
 	else
 		VectorScale( g_globalvars.v_forward, 800, newmis->s.v.velocity );
 	SetVector( newmis->s.v.avelocity, 0, 0, -500 );
@@ -399,7 +399,7 @@ void UnfreezeGravity( gedict_t *p )
 	p->maxspeed = cvar("sv_maxspeed");
 
 	if ( p->ctf_flag & CTF_RUNE_HST )
-		p->maxspeed *= min(cvar("k_ctf_rune_power_hst"), 1.0);
+		p->maxspeed *= 1 + (cvar("k_ctf_rune_power_hst") / 4);
 
 	p->gravity = 1;
 	p->ctf_freeze = 0;

--- a/src/runes.c
+++ b/src/runes.c
@@ -223,7 +223,7 @@ void RuneTouch()
 
 	if ( other->ctf_flag & CTF_RUNE_HST )
 	{
-		other->maxspeed *= 1.25;
+		other->maxspeed *= (cvar("k_ctf_rune_power_hst") / 4) + 1;
 		// other->s.v.items = (int) other->s.v.items | CTF_RUNE_HST;
 		G_sprint( other, 2, "You got the %s rune\n", redtext("haste") );
 	}

--- a/src/runes.c
+++ b/src/runes.c
@@ -223,7 +223,7 @@ void RuneTouch()
 
 	if ( other->ctf_flag & CTF_RUNE_HST )
 	{
-		other->maxspeed *= (cvar("k_ctf_rune_power_hst") / 4) + 1;
+		other->maxspeed *= (cvar("k_ctf_rune_power_hst") / 8) + 1;
 		// other->s.v.items = (int) other->s.v.items | CTF_RUNE_HST;
 		G_sprint( other, 2, "You got the %s rune\n", redtext("haste") );
 	}

--- a/src/weapons.c
+++ b/src/weapons.c
@@ -1828,7 +1828,7 @@ void W_Attack()
 	case IT_AXE:
         if ( self->ctf_flag & CTF_RUNE_HST )
 		{
-			self->attack_finished = g_globalvars.time + 0.3;
+			self->attack_finished = g_globalvars.time + 0.5 - (0.1 * min(cvar("k_ctf_rune_power_hst"), 1.0));
 			HasteSound( self );
 		}
     	else
@@ -1854,7 +1854,7 @@ void W_Attack()
 
 		if ( self->ctf_flag & CTF_RUNE_HST )
 		{
-			self->attack_finished = g_globalvars.time + 0.3;
+			self->attack_finished = g_globalvars.time + 0.5 - (0.1 * min(cvar("k_ctf_rune_power_hst"), 1.0));
 			HasteSound( self );
 		}
 		else
@@ -1875,7 +1875,7 @@ void W_Attack()
 
     if ( self->ctf_flag & CTF_RUNE_HST )
 		{
-			self->attack_finished = g_globalvars.time + 0.4;
+			self->attack_finished = g_globalvars.time + 0.5 - (0.05 * min(cvar("k_ctf_rune_power_hst"), 1.0));
 			HasteSound( self );
 		}
 		else
@@ -1901,7 +1901,7 @@ void W_Attack()
 
 		if ( self->ctf_flag & CTF_RUNE_HST )
 		{
-			self->attack_finished = g_globalvars.time + 0.3;
+			self->attack_finished = g_globalvars.time + 0.5 - (0.1 * min(cvar("k_ctf_rune_power_hst"), 1.0));
 			HasteSound( self );
 		}
 		else
@@ -1915,7 +1915,7 @@ void W_Attack()
 
 		if ( self->ctf_flag & CTF_RUNE_HST )
 		{
-			self->attack_finished = g_globalvars.time + 0.4;
+			self->attack_finished = g_globalvars.time + 0.5 - (0.05 * min(cvar("k_ctf_rune_power_hst"), 1.0));
 			HasteSound( self );
 		}
 		else

--- a/src/weapons.c
+++ b/src/weapons.c
@@ -1828,7 +1828,7 @@ void W_Attack()
 	case IT_AXE:
         if ( self->ctf_flag & CTF_RUNE_HST )
 		{
-			self->attack_finished = g_globalvars.time + 0.5 - (0.1 * min(cvar("k_ctf_rune_power_hst"), 1.0));
+			self->attack_finished = g_globalvars.time + 0.5 - (cvar("k_ctf_rune_power_hst") / 10);
 			HasteSound( self );
 		}
     	else
@@ -1854,7 +1854,7 @@ void W_Attack()
 
 		if ( self->ctf_flag & CTF_RUNE_HST )
 		{
-			self->attack_finished = g_globalvars.time + 0.5 - (0.1 * min(cvar("k_ctf_rune_power_hst"), 1.0));
+			self->attack_finished = g_globalvars.time + 0.5 - (cvar("k_ctf_rune_power_hst") / 10);
 			HasteSound( self );
 		}
 		else
@@ -1875,7 +1875,7 @@ void W_Attack()
 
     if ( self->ctf_flag & CTF_RUNE_HST )
 		{
-			self->attack_finished = g_globalvars.time + 0.5 - (0.05 * min(cvar("k_ctf_rune_power_hst"), 1.0));
+			self->attack_finished = g_globalvars.time + 0.5 - (cvar("k_ctf_rune_power_hst") / 20);
 			HasteSound( self );
 		}
 		else
@@ -1901,7 +1901,7 @@ void W_Attack()
 
 		if ( self->ctf_flag & CTF_RUNE_HST )
 		{
-			self->attack_finished = g_globalvars.time + 0.5 - (0.1 * min(cvar("k_ctf_rune_power_hst"), 1.0));
+			self->attack_finished = g_globalvars.time + 0.5 - (cvar("k_ctf_rune_power_hst") / 10);
 			HasteSound( self );
 		}
 		else
@@ -1915,7 +1915,7 @@ void W_Attack()
 
 		if ( self->ctf_flag & CTF_RUNE_HST )
 		{
-			self->attack_finished = g_globalvars.time + 0.5 - (0.05 * min(cvar("k_ctf_rune_power_hst"), 1.0));
+			self->attack_finished = g_globalvars.time + 0.5 - (cvar("k_ctf_rune_power_hst") / 20);
 			HasteSound( self );
 		}
 		else

--- a/src/world.c
+++ b/src/world.c
@@ -831,10 +831,10 @@ void FirstFrame	( )
 	RegisterCvar("k_ctf_custom_models");
 	RegisterCvar("k_ctf_hook");
 	RegisterCvar("k_ctf_runes");
-	RegisterCvar("k_ctf_rune_power_str", "2.0");
-	RegisterCvar("k_ctf_rune_power_res", "2.0");
-	RegisterCvar("k_ctf_rune_power_rgn", "2.0");
-	RegisterCvar("k_ctf_rune_power_hst", "2.0");
+	RegisterCvarEx("k_ctf_rune_power_str", "2.0");
+	RegisterCvarEx("k_ctf_rune_power_res", "2.0");
+	RegisterCvarEx("k_ctf_rune_power_rgn", "2.0");
+	RegisterCvarEx("k_ctf_rune_power_hst", "2.0");
 	RegisterCvar("k_ctf_ga");
 	RegisterCvar("k_ctf_based_spawn"); // spawn players on the base (red/blue)
 //}

--- a/src/world.c
+++ b/src/world.c
@@ -831,6 +831,10 @@ void FirstFrame	( )
 	RegisterCvar("k_ctf_custom_models");
 	RegisterCvar("k_ctf_hook");
 	RegisterCvar("k_ctf_runes");
+	RegisterCvar("k_ctf_rune_power_str", "2.0");
+	RegisterCvar("k_ctf_rune_power_res", "2.0");
+	RegisterCvar("k_ctf_rune_power_rgn", "2.0");
+	RegisterCvar("k_ctf_rune_power_hst", "2.0");
 	RegisterCvar("k_ctf_ga");
 	RegisterCvar("k_ctf_based_spawn"); // spawn players on the base (red/blue)
 //}


### PR DESCRIPTION
New cvars allow one to modify independently each rune power level in CTF:

- k_ctf_rune_power_str (Strength), 
- k_ctf_rune_power_res (Resistance),
- k_ctf_rune_power_rgn (Regeneration),
- k_ctf_rune_power_hst (Haste).

Default value is 2, as it has always been (previously hardcoded).