### PR TITLE
MATCHLESS: support new cvar k_matchless_max_idle_time which forces id…

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -814,6 +814,8 @@ typedef struct gedict_s {
 	float           dmg;
 	float           lip;
 	float           attack_finished;
+	float           attack_finished_last;
+	int             attack_idle_time; // keep track of last time client fired weapon in matchless
 	float           pain_finished;
 
 	float           invincible_finished;

--- a/resources/example-configs/ktx/configs/usermodes/matchless/default.cfg
+++ b/resources/example-configs/ktx/configs/usermodes/matchless/default.cfg
@@ -3,6 +3,7 @@ set k_mode                      3    // server mode (1 = duel, 2 = team, 3 = ffa
 
 // matchless settings
 set k_matchless_countdown       0    // countdown in matchless mode (0 = off, 1 = on)
+set k_matchless_max_idle_time   0    // maximum time a user can be idle before being forced to spectator in matchless
 set k_pow_min_players           1    // number of players on server required for powerups to be turned on
 set k_pow_check_time            10   // how often should ktx check if the k_pow_min_players requirement has been met (seconds)
 set k_no_vote_map               0    // allow map voting and /next_map (0 = allow voting, 1 = disallow voting)

--- a/src/match.c
+++ b/src/match.c
@@ -474,7 +474,30 @@ void CheckOvertime()
 // Tells the time every now and then.
 void TimerThink ()
 {
-//	G_bprint(2, "left %2d:%2d\n", (int)self->cnt, (int)self->cnt2);
+	gedict_t *p;
+	int max_idle_time = cvar( "k_matchless_max_idle_time" ) ? cvar( "k_matchless_max_idle_time" ) : 0;
+
+	//if in matchless mode, check that the user hasn't exceeded k_matchless_max_idle_time
+	if ( k_matchLess && CountPlayers() && match_in_progress && max_idle_time ){
+		for( p = world; (p = find_client( p )); )
+		{
+			if( p->attack_finished != p->attack_finished_last ) {
+				p->attack_finished_last=p->attack_finished;
+				p->attack_idle_time=0;
+			} else {
+				if( p->attack_idle_time > max_idle_time ){
+					G_sprint(p, 2, "You were forced to reconnect as spectator by exceeding the maximum idle time of %i seconds.\n", max_idle_time);
+					stuffcmd_flags(p, STUFFCMD_IGNOREINDEMO, "spectator 1\n");
+					if ( !strnull( ezinfokey(p, "Qizmo") ) )
+						stuffcmd_flags(p, STUFFCMD_IGNOREINDEMO, "say ,:dis\nwait;wait;wait; say ,:reconnect\n");
+					else
+						stuffcmd_flags(p, STUFFCMD_IGNOREINDEMO, "disconnect\nwait;wait;reconnect\n");
+				}
+				p->attack_idle_time++;
+			}
+		}
+	}
+
 
 	if( !k_matchLess && !CountPlayers() ) {
 		EndMatch( 1 );

--- a/src/world.c
+++ b/src/world.c
@@ -709,6 +709,7 @@ void FirstFrame	( )
 	RegisterCvar("k_auto_xonx"); // switch XonX mode dependant on players + specs count
 	RegisterCvar("k_matchless");
 	RegisterCvar("k_matchless_countdown");
+	RegisterCvar("k_matchless_max_idle_time"); // maximum time user can be idle in matchless mode
 	RegisterCvar("k_use_matchless_dir"); // use configs/usermodes/matchless instead of configs/usermodes/ffa in matchless mode
 	RegisterCvar("k_disallow_kfjump");
 	RegisterCvar("k_disallow_krjump");


### PR DESCRIPTION
…le players to spec after x seconds without firing