### PR TITLE
MATCHLESS: k_matchless_max_idle_time - warn user 30 seconds (or half …

### DIFF
--- a/include/g_local.h
+++ b/include/g_local.h
@@ -951,6 +951,9 @@ extern	int   k_teleport_cap;	// cap for keeping velocity through tele
 
 extern	int   k_practice;		// is server in practice mode
 extern	int   k_matchLess;	    // is server in matchLess mode
+extern  int   k_matchLess_idle_time;
+extern  int   k_matchLess_idle_warn;
+
 extern  gameType_t 	  k_mode;   // game type: DUEL, TP, FFA
 extern	int   k_lastvotedmap;	// last voted map, used for agree command?
 // { CTF

--- a/src/globals.c
+++ b/src/globals.c
@@ -56,6 +56,8 @@ int k_teleport_cap = 24;	// cap for keeping velocity through tele
 // }
 int	k_practice;			// is server in practice mode
 int	k_matchLess;		// is server in matchLess mode
+int     k_matchLess_idle_time;
+int     k_matchLess_idle_warn;
 gameType_t 	  k_mode;   // game type: DUEL, TP, FFA
 int	k_lastvotedmap;		// last voted map, used for agree command?
 

--- a/src/match.c
+++ b/src/match.c
@@ -475,23 +475,24 @@ void CheckOvertime()
 void TimerThink ()
 {
 	gedict_t *p;
-	int max_idle_time = cvar( "k_matchless_max_idle_time" ) ? cvar( "k_matchless_max_idle_time" ) : 0;
 
 	//if in matchless mode, check that the user hasn't exceeded k_matchless_max_idle_time
-	if ( k_matchLess && CountPlayers() && match_in_progress && max_idle_time ){
+	if ( k_matchLess && CountPlayers() && match_in_progress && k_matchLess_idle_time){
 		for( p = world; (p = find_client( p )); )
 		{
 			if( p->attack_finished != p->attack_finished_last ) {
-				p->attack_finished_last=p->attack_finished;
-				p->attack_idle_time=0;
+				p->attack_finished_last = p->attack_finished;
+				p->attack_idle_time = 0;
 			} else {
-				if( p->attack_idle_time > max_idle_time ){
-					G_sprint(p, 2, "You were forced to reconnect as spectator by exceeding the maximum idle time of %i seconds.\n", max_idle_time);
+				if( p->attack_idle_time > k_matchLess_idle_time ){
+					G_sprint(p, 2, "You were forced to reconnect as spectator by exceeding the maximum idle time of %i seconds.\n", k_matchLess_idle_time);
 					stuffcmd_flags(p, STUFFCMD_IGNOREINDEMO, "spectator 1\n");
 					if ( !strnull( ezinfokey(p, "Qizmo") ) )
 						stuffcmd_flags(p, STUFFCMD_IGNOREINDEMO, "say ,:dis\nwait;wait;wait; say ,:reconnect\n");
 					else
 						stuffcmd_flags(p, STUFFCMD_IGNOREINDEMO, "disconnect\nwait;wait;reconnect\n");
+				} else if  ( p->attack_idle_time == k_matchLess_idle_warn ) {
+					G_sprint(p, 2, "\x87%s You will be forced to spectate if you do not fire within %i seconds!\n", redtext( "WARNING:" ), (k_matchLess_idle_time-k_matchLess_idle_warn));
 				}
 				p->attack_idle_time++;
 			}

--- a/src/world.c
+++ b/src/world.c
@@ -948,6 +948,8 @@ void FirstFrame	( )
 // below globals changed only here
 
 	k_matchLess = cvar( "k_matchless" );
+	k_matchLess_idle_time = cvar( "k_matchless_max_idle_time" ) ? cvar( "k_matchless_max_idle_time" ) : 0;
+	k_matchLess_idle_warn = k_matchLess_idle_time - (k_matchLess_idle_time > 30 ? 30 : (k_matchLess_idle_time/2));
 	if ( !cvar( "deathmatch" ) || cvar( "coop" ) )
 	{
 		k_matchLess = 1; // treat coop or singleplayer as matchLess


### PR DESCRIPTION
…of maximum idle time) before forcing them to spectate