### PR TITLE
MAPCYCLE fixes - minor

### DIFF
--- a/src/g_main.c
+++ b/src/g_main.c
@@ -460,7 +460,6 @@ void G_ShutDown()
 	extern qbool force_map_reset;
 
 	char *map = g_globalvars.mapname;
-	int i;
 
 	AbortElect();
 
@@ -472,9 +471,6 @@ void G_ShutDown()
 
 	cvar_set( "_k_lastmap", ( strnull( map ) || force_map_reset ? "" : map ) );
 	cvar_fset( "_k_pow_last", Get_Powerups() );
-
-	if ( (i = IsMapInCycle( map )) )
-		cvar_fset( "_k_last_cycle_map", i );
 }
 
 

--- a/src/maps.c
+++ b/src/maps.c
@@ -553,7 +553,7 @@ char *SelectMapInCycle(char *buf, int buf_size)
 			trap_cvar_string( mapid, newmap, sizeof(newmap) );
 			break;
 		} else {
-			G_bprint(2, "Player requirements not met for map #%d in the map cycle, continuing to next map. (Minimum: %d, Maximum: %d)\n", i, minp, maxp);
+			G_bprint(2, "Player requirements not met for map #%d in the map cycle, continuing to next map. (Minimum: %d, Maximum: %d)\n", (i+1), minp, maxp);
 		}
 		i++;
 	}

--- a/src/maps.c
+++ b/src/maps.c
@@ -537,8 +537,8 @@ char *SelectMapInCycle(char *buf, int buf_size)
 			return buf;
 	}
 
-	if ( !(i = IsMapInCycle( g_globalvars.mapname) ) ){ // ok map found in map list, select next map
-		if ( !(i = cvar( "_k_last_cycle_map" ) ) ){
+	if ( !(i = cvar( "_k_last_cycle_map" ) ) ){
+		if ( !(i = IsMapInCycle( g_globalvars.mapname) ) ){ // ok map found in map list, select next map
 			i=0;
 		}
 	}
@@ -562,6 +562,9 @@ char *SelectMapInCycle(char *buf, int buf_size)
 		trap_cvar_string( "k_ml_0", newmap, sizeof(newmap) );
 
 	strlcpy(buf, newmap, buf_size);
+
+	if ( (i = IsMapInCycle( buf )) )
+		cvar_fset( "_k_last_cycle_map", i );
 
 	return buf;
 }


### PR DESCRIPTION
Stay in mapcycle even when voted map exists in cycle.  Show proper mapcycle number when warning about min/max player requirements not being met.