### PR TITLE
FUN STATS: Last RA / RA Spawns

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -176,6 +176,10 @@ typedef struct player_stats_s {
 	// time stats
 	float control_time; // time spent in control
 
+	// red armor stats
+	int ra_spawns; // number of ra spawns
+	float last_ra_time; // last time ra was taken
+
 	// rocket arena
 	int wins;	//number of wins they have
 	int loses;	//number of loses they have

--- a/resources/example-configs/ktx/ktx.cfg
+++ b/resources/example-configs/ktx/ktx.cfg
@@ -35,6 +35,7 @@ set k_fallbunny               1         // fallbunny (0 = off (broken ankle), 1 
 set k_disallow_kfjump         1         // kfjump (0 = on, 1 = off)
 set k_disallow_krjump         1         // krjump (0 = on, 1 = off)
 set k_teamoverlay             0         // team overlay (0 = disabled, 1 = enabled)
+set k_fun_stats               1         // fun end game stats like "Last RA" (0 = disabled, 1 = enabled)
 set k_classic_shotgun         1         // use precisely shown sg/ssg hits for each pellet fired
 
 // matchless mode

--- a/src/commands.c
+++ b/src/commands.c
@@ -202,6 +202,7 @@ void mapcycle ();
 void airstep();
 void ToggleExclusive();
 void ToggleNewCoopNm();
+void ToggleFunStats();
 void ToggleVwep();
 void TogglePause();
 void ToggleArena();
@@ -615,6 +616,7 @@ const char CD_NODESC[] = "no desc";
 #define CD_CMDSLIST_DL  (CD_NODESC) // skip
 
 #define CD_DEMOMARK     "put mark in the demo"
+#define CD_FUNSTATS     "fun end game stats"
 
 #define CD_BOTCOMMAND   "bot configuration"
 
@@ -950,6 +952,7 @@ cmd_t cmds[] = {
 	{ "dumpent",     dumpent,                   0    , CF_BOTH | CF_PARAMS, CD_DUMPENT },
 	{ "votecoop",    votecoop,                  0    , CF_PLAYER | CF_MATCHLESS, CD_VOTECOOP },
 	{ "coop_nm_pu",	 ToggleNewCoopNm,           0    , CF_PLAYER | CF_MATCHLESS, CD_COOPNMPU },
+	{ "funstats",	 ToggleFunStats,            0    , CF_PLAYER | CF_SPC_ADMIN, CD_FUNSTATS },
 	{ "demomark",	 DemoMark,                  0    , CF_BOTH, CD_DEMOMARK },
 
 #ifdef BOT_SUPPORT
@@ -6214,6 +6217,14 @@ void ToggleNewCoopNm()
 		return;
 
 	cvar_toggle_msg( self, "k_nightmare_pu", redtext("New Nightmare mode (drops powerups)") );
+}
+
+void ToggleFunStats()
+{
+	if ( match_in_progress )
+		return;
+
+	cvar_toggle_msg( self, "k_fun_stats", redtext("fun end game stats") );
 }
 
 // { yawn mode related

--- a/src/items.c
+++ b/src/items.c
@@ -465,6 +465,14 @@ void armor_touch()
 
 	playername = other->netname;
 
+	// Record player red armor stats.
+	other->ps.last_ra_time = g_globalvars.time;
+	if (bit & IT_ARMOR3) {
+		if (other->spawn_time + 1 > g_globalvars.time) {
+			other->ps.ra_spawns++;
+		}
+	}
+
 	/*
 	log_printf( "\t\t\t<pickmi time=\"%f\" item=\"%s\" player=\"%s\" value=\"%d\" />\n",
 				g_globalvars.time - match_start_time,

--- a/src/match.c
+++ b/src/match.c
@@ -972,6 +972,7 @@ void PrintCountdown( int seconds )
 // Fraglimit xxx
 // Overtime   xx		Overtime printout, supports sudden death display
 // Powerups   On|Off|QPRS
+// FunStats   On
 // Dmgfrags   On // optional
 // Noweapon
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -454,7 +454,7 @@ void StatsToFile(void)
 }
 
 
-float maxfrags, maxdeaths, maxfriend, maxeffi, maxcaps, maxdefends, maxsgeffi;
+float maxfrags, maxdeaths, maxfriend, maxeffi, maxcaps, maxdefends, maxsgeffi, maxlastra;
 int maxspree, maxspree_q, maxdmgg, maxdmgtd, maxrlkills;
 
 void OnePlayerStats(gedict_t *p, int tp)
@@ -634,6 +634,11 @@ void OnePlayerStats(gedict_t *p, int tp)
 		G_bprint(2, "  %s: %d\n", redtext("SpawnFrags"), p->ps.spawn_frags);
 	}
 
+	// ra spawns
+	if (!isCTF() && !lgc_enabled()) {
+		G_bprint(2, "  %s: %d\n", redtext(" RA Spawns"), p->ps.ra_spawns);
+	}
+
 	if (lgc_enabled() && a_lg) {
 		int over = p->ps.lgc_overshaft;
 		int under = p->ps.lgc_undershaft;
@@ -659,6 +664,7 @@ void OnePlayerStats(gedict_t *p, int tp)
     maxdmgtd   = max((int)(p->ps.dmg_t / p->deaths), maxdmgtd);
 	maxrlkills = max(p->ps.wpn[wpRL].ekills, maxrlkills);
 	maxsgeffi  = max(e_sg, maxsgeffi);
+	maxlastra  = max(p->ps.last_ra_time, maxlastra);
 }
 
 // Players statistics printout here
@@ -678,7 +684,7 @@ void PlayersStats(void)
 	// Probably low enough for a start value :)
 	maxfrags = -999999;
 
-	maxeffi = maxfriend = maxdeaths = maxcaps = maxdefends = maxsgeffi = 0;
+	maxeffi = maxfriend = maxdeaths = maxcaps = maxdefends = maxsgeffi = maxlastra = 0;
 	maxspree = maxspree_q = maxdmgtd = maxdmgg = maxrlkills = 0;
 
 	tp = isTeam() || isCTF();
@@ -950,6 +956,27 @@ void TopStats(void)
 					f1 = 1;
 				}
 				p = find_plrghst ( p, &from );
+			}
+		}
+	}
+
+	if ( cvar("k_fun_stats") )
+	{
+		G_bprint(2, "\n");
+
+		if ( maxlastra && deathmatch != 1 )
+		{
+			G_bprint( 2, "    Last RA: ");
+			from = f1 = 0;
+			p = find_plrghst( world, &from );
+			float time_remaining = match_end_time - maxlastra;
+			while( p ) {
+				if ( p->ps.last_ra_time == maxlastra ) {
+					G_bprint(2, "%s%s%s \220%1.2fs remaining\221\n", (f1 ? "             " : ""),
+							( isghost( p ) ? "\203" : "" ), getname( p ), time_remaining );
+					f1 = 1;
+				}
+				p = find_plrghst( p, &from );
 			}
 		}
 	}

--- a/src/world.c
+++ b/src/world.c
@@ -945,6 +945,8 @@ void FirstFrame	( )
 
 	RegisterCvar("k_lgcmode");
 
+	RegisterCvarEx("k_fun_stats", "0");
+
 // below globals changed only here
 
 	k_matchLess = cvar( "k_matchless" );


### PR DESCRIPTION
* Always shows "RA Spawns" per-player at the end of the game.
* If "funstats" is enabled it shows "Last RA" time after normal end game stats
  - `set k_fun_stats 1` for servers to enable by default
  - `funstats` command to toggle by players in game

Example stats:
![Screen Shot 2020-10-28 at 12 49 10 AM](https://user-images.githubusercontent.com/11351/97408783-d666a680-18b9-11eb-863b-903008b6e1cb.png)

---

I'm making fun stats disabled by default, but I expect North American servers to always enable it in their configurations.
