### PR TITLE
CTF | grappling hook improvements, alternate grapple velocities

### DIFF
--- a/include/g_local.h
+++ b/include/g_local.h
@@ -195,6 +195,7 @@ float           g_random( void );
 float           crandom( void );
 int				i_rnd( int from, int to );
 float           dist_random (float minValue, float maxValue, float spreadFactor);
+float           next_frame();
 gedict_t       *spawn( void );
 void            ent_remove( gedict_t * t );
 void            soft_ent_remove (gedict_t* ent);

--- a/include/progs.h
+++ b/include/progs.h
@@ -990,7 +990,6 @@ typedef struct gedict_s {
 	qbool on_hook;              // are we on the grapple?
 	qbool hook_out;             // is the grapple in flight?
 	int ctf_flag;                  // do we have a rune or flag?
-	float ctf_freeze;              // removes jitterness from grapple 
 	float regen_time;              // time to update health if regen rune
 	float rune_sound_time;         // dont spam rune sounds (1 per second)
 	float carrier_frag_time;       // used for carrier assists
@@ -998,6 +997,7 @@ typedef struct gedict_s {
 	float rune_notify_time;        // already have a rune spam prevention
 	float carrier_hurt_time;       // time we last hurt enemy carrier
 	float rune_pickup_time;        // time we picked up current rune
+	float hook_damage_time;        // manage dps dealt to hooked enemies
 	char *last_rune;			   // name of last rune we send to client
 	float	items2;				   // using  ZQ_ITEMS2 extension in mvdsv we can use per client sigils for runes
 

--- a/resources/example-configs/ktx/configs/usermodes/matchless/ctf.cfg
+++ b/resources/example-configs/ktx/configs/usermodes/matchless/ctf.cfg
@@ -13,6 +13,7 @@ set k_admins 1
 watervis 1 // turn on watervis for CTF
 k_ctf_runes 1 // allow runes
 k_ctf_hook 1 // allow hook
+k_ctf_cr_hook 0 // toggle clan-ring 3.0 hook settings
 k_ctf_based_spawn 0 // 
 pm_airstep 0 // turn off jumping up stairs
 k_spw 1 // KT spawnsafety

--- a/src/commands.c
+++ b/src/commands.c
@@ -60,6 +60,7 @@ void FlagStatus();
 void TossFlag();
 void norunes();
 void nohook();
+void crhook();
 void noga();
 void mctf();
 void CTFBasedSpawn();
@@ -497,6 +498,7 @@ const char CD_NODESC[] = "no desc";
 #define CD_TOSSFLAG     "drop flag (CTF)"
 #define CD_FLAGSTATUS   "show flags status (CTF)"
 #define CD_NOHOOK       "toggle hook (CTF)"
+#define CD_CRHOOK       "toggle CRCTF 3.0 Hook settings (CTF)"
 #define CD_NORUNES      "toggle runes (CTF)"
 #define CD_NOGA         "toggle green armor on spawn (CTF)"
 #define CD_MCTF         "disable hook+runes (CTF)"
@@ -840,6 +842,7 @@ cmd_t cmds[] = {
 	{ "tossrune",    TossRune,                  0    , CF_PLAYER | CF_MATCHLESS, CD_TOSSRUNE },
 	{ "tossflag",    TossFlag,                  0    , CF_PLAYER | CF_MATCHLESS, CD_TOSSFLAG },
 	{ "nohook",      nohook,                    0    , CF_BOTH_ADMIN | CF_MATCHLESS, CD_NOHOOK },
+	{ "crhook",      crhook,                    0    , CF_BOTH_ADMIN | CF_MATCHLESS, CD_CRHOOK },
 	{ "norunes",     norunes,                   0    , CF_BOTH_ADMIN | CF_MATCHLESS, CD_NORUNES },
 	{ "noga",        noga,                      0    , CF_BOTH_ADMIN | CF_MATCHLESS, CD_NOGA },
 	{ "mctf",        mctf,                      0    , CF_BOTH_ADMIN | CF_MATCHLESS, CD_MCTF },

--- a/src/ctf.c
+++ b/src/ctf.c
@@ -673,6 +673,20 @@ void nohook()
 	}
 }
 
+void crhook()
+{
+	if (match_in_progress)
+		return;
+
+	if (!isCTF())
+	{
+		G_sprint(self, 2, "Can't do this in non CTF mode\n");
+		return;
+	}
+
+	cvar_toggle_msg(self, "k_ctf_cr_hook", redtext("clanring 3.0 hook"));
+}
+
 void noga()
 {
 	if( match_in_progress && !k_matchLess )

--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -116,6 +116,11 @@ void initialise_spawned_ent(gedict_t* ent)
 	PR2SetStringFieldOffset(ent, noise3);
 }
 
+float next_frame( )
+{
+	return g_globalvars.time + g_globalvars.frametime;
+}
+
 gedict_t *spawn(  )
 {
 	gedict_t *t = &g_edicts[trap_spawn(  )];

--- a/src/player.c
+++ b/src/player.c
@@ -113,7 +113,7 @@ void player_chain1()
 {
 	self->s.v.frame = 137;
 	self->think = ( func_t ) player_chain2;
- 	self->s.v.nextthink = g_globalvars.time + 0.1;
+ 	self->s.v.nextthink = next_frame();
 	self->s.v.weaponframe = 2;
 	GrappleThrow();
 }
@@ -122,20 +122,25 @@ void player_chain2()
 {
 	self->s.v.frame = 138;
 	self->think = ( func_t ) player_chain3;
-	self->s.v.nextthink = g_globalvars.time + 0.1;
+	self->s.v.nextthink = next_frame();
 	self->s.v.weaponframe = 3;
 }
 
 void player_chain3()
 {
 	self->s.v.frame = 139;
-	self->think = ( func_t ) player_chain4;
-	self->s.v.nextthink = g_globalvars.time + 0.1;
 	self->s.v.weaponframe = 3;
+
 	if ( !self->hook_out )
 		player_chain5();
+
 	else if ( vlen(self->s.v.velocity) >= 750 )
 		player_chain4();
+
+	else {
+		self->think = ( func_t ) player_chain3;
+		self->s.v.nextthink = next_frame();
+	}
 }
 
 void player_chain4()
@@ -144,22 +149,28 @@ void player_chain4()
 	// Frame 139 is a decent alternative especially given that 73 never looked good anyway
 	// self->s.v.frame = 73;
 	self->s.v.frame = 139;
-	self->think = ( func_t ) player_chain5;
-	self->s.v.nextthink = g_globalvars.time + 0.1;
 	self->s.v.weaponframe = 4;
+
 	if ( !self->hook_out )
 		player_chain5();
+
 	else if ( vlen(self->s.v.velocity) < 750 )  
 		player_chain3(); 
+
+	else {
+		self->think = ( func_t ) player_chain4;
+		self->s.v.nextthink = next_frame();
+	}
 }
 
 void player_chain5()
 {
 	self->s.v.frame = 140;
-	self->walkframe = 0;
-	self->think = ( func_t ) player_run;
-	self->s.v.nextthink = g_globalvars.time + 0.1;
 	self->s.v.weaponframe = 5;
+	self->walkframe = 0;
+
+	self->think = ( func_t ) player_run;
+	self->s.v.nextthink = next_frame();
 }
 
 void player_shot1()

--- a/src/world.c
+++ b/src/world.c
@@ -832,6 +832,7 @@ void FirstFrame	( )
 //{ ctf
 	RegisterCvar("k_ctf_custom_models");
 	RegisterCvar("k_ctf_hook");
+	RegisterCvar("k_ctf_cr_hook"); // toggle for clan-ring style hook
 	RegisterCvar("k_ctf_runes");
 	RegisterCvarEx("k_ctf_rune_power_str", "2.0");
 	RegisterCvarEx("k_ctf_rune_power_res", "2.0");


### PR DESCRIPTION
I've been playing some **KTX CTF** recently, and noticed that the hook didn't feel quite right compared with the original 3wave implementation.  This PR introduces a few improvements:

## Bug Fixes
### position updates
hook throw/pull and tracking have hardcoded 100ms updates.  This can get out of sync with the server's ticrate, and causes noticeable choppiness & "jitter" issues

* sync hook throw/pull/track updates to server ticrate using `next_frame()` util [`time + frametime`]
* remove gravity hack (previous attempt at mitigating hook issues?)

### Glitchy hook animations 
While grappling, the weapon animation flickers back & forth between `weaponframe 3` and `weaponframe 4`

* fix weaponframe calls in `player_chain` functions in `player.c`
* sync `player_chain` func calls w/ server ticrate using `next_frame()` util [`time + frametime`]

The hook and player movement feels much smoother and responsive, feels closer to the original threewave implementation, and the gravity hack is no longer required.  

The weapon animation glitches no longer occur in 90% of cases, but still seem to bug out when the player is colliding with another brush/entity.

## Alternate Throw Speed [cvar/admin toggle]
in netquake, the clan-ring mod updated the original hook velocities to have a faster throw speed back in the late 90s.  I don't think the change was ever ported over to QW, but it's an interesting option that would be nice to support in KTX.

* adds a cvar / admin command (off by default) to toogle hook throw speed  
* change hook throw velocity from 800 -> 1200 when `crhook` is enabled
* allows players to "cancel" a hook throw before it anchors to a surface (`crhook` only)