### PR TITLE
Elected admin tweaks

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -308,6 +308,9 @@ void BecomeAdmin(gedict_t *p, int adm_flags)
 
 	p->k_admin |= adm_flags;
 
+	// Any previous votes should be invalidated
+	memset(&p->v, 0, sizeof(p->v));
+
 	on_admin(p);
 }
 

--- a/src/match.c
+++ b/src/match.c
@@ -817,6 +817,18 @@ static void SM_PrepareClients()
 			pl_team = getteam(p);
 			p->k_teamnum = 0;
 
+			// elected admins lose rights when match starts -> they need to be re-elected
+			if (p->k_admin & AF_ADMIN)
+			{
+				p->k_admin = (p->k_admin & ~(AF_ADMIN));
+
+				if (!p->k_admin)
+				{
+					G_bprint(2, "%s is no longer an %s\n", p->netname, redtext("admin"));
+					on_unadmin(p);
+				}
+			}
+
 			if (!strnull(pl_team))
 			{
 				i = 665;


### PR DESCRIPTION
This PR tackles 2 things from #127:
- when a player became an elected admin, all his previous votes are invalidated
- an elected admin loses his admin rights when the match starts

These changes were done by @meag in his fork. I just copy+pasted it into my fork, and made the PR.