### PR TITLE
Improved map voting mechanics for admins.

### DIFF
--- a/include/g_local.h
+++ b/include/g_local.h
@@ -601,7 +601,7 @@ extern int cmds_cnt; // count of commands in 'cmds'
 //
 // DoCommand/DoCommand_Name return codes
 // return non-negative value if command success
-// 
+//
 #define DO_OUT_OF_RANGE_CMDS			(-1) // if command is out of range in 'cmds' array or not found
 #define DO_WRONG_CLASS					(-2) // if wrong class
 #define DO_ACCESS_DENIED				(-3) // if access denied
@@ -817,6 +817,7 @@ void StuffMaps(gedict_t *p);
 void GetMapList(void);
 
 char* GetMapName(int imp);
+int GetMapNum(char *mapname);
 void DoSelectMap(int iMap);
 void SelectMap();
 void VoteMap();

--- a/src/admin.c
+++ b/src/admin.c
@@ -745,6 +745,34 @@ void AdminForceBreak()
 	EndMatch(0);
 }
 
+void AdminForceMap()
+{
+	if (!is_adm(self))
+	{
+		return;
+	}
+	if (!k_matchLess && match_in_progress)
+	{
+		G_sprint(self, 2, "Match currently in progress. Use %s or %s to terminate.\n", redtext("break"), redtext("forcebreak"));
+		return;
+	}
+	if (trap_CmdArgc() < 2)
+	{
+		G_sprint(self, 2, "Usage: forcemap %s\n", redtext("<mapname>"));
+		return;
+	}
+	char mapname[128];
+	trap_CmdArgv(1, mapname, sizeof(mapname));
+	extern int GetMapNum(char *);
+	if (GetMapNum(mapname) <= 0)
+	{
+		G_sprint(self, 2, "Map %s not available on this server.\n", redtext(mapname));
+		return;
+	}
+	G_bprint(2, "%s forces a map change to %s!\n", self->netname, redtext(mapname));
+	changelevel(mapname);
+}
+
 void PlayerStopFire(gedict_t *p)
 {
 	stuffcmd_flags(p, STUFFCMD_IGNOREINDEMO, "-attack\n");

--- a/src/admin.c
+++ b/src/admin.c
@@ -747,28 +747,35 @@ void AdminForceBreak()
 
 void AdminForceMap()
 {
+	char mapname[128];
+
 	if (!is_adm(self))
 	{
 		return;
 	}
+
 	if (!k_matchLess && match_in_progress)
 	{
 		G_sprint(self, 2, "Match currently in progress. Use %s or %s to terminate.\n", redtext("break"), redtext("forcebreak"));
+
 		return;
 	}
+
 	if (trap_CmdArgc() < 2)
 	{
 		G_sprint(self, 2, "Usage: forcemap %s\n", redtext("<mapname>"));
+
 		return;
 	}
-	char mapname[128];
+
 	trap_CmdArgv(1, mapname, sizeof(mapname));
-	extern int GetMapNum(char *);
 	if (GetMapNum(mapname) <= 0)
 	{
 		G_sprint(self, 2, "Map %s not available on this server.\n", redtext(mapname));
+
 		return;
 	}
+
 	G_bprint(2, "%s forces a map change to %s!\n", self->netname, redtext(mapname));
 	changelevel(mapname);
 }

--- a/src/commands.c
+++ b/src/commands.c
@@ -31,6 +31,7 @@ void PlayerBreak();
 void ReqAdmin();
 void AdminForceStart();
 void AdminForceBreak();
+void AdminForceMap();
 void AdminSwapAll();
 void TogglePreWar();
 void ToggleMapLock();
@@ -365,6 +366,7 @@ const char CD_NODESC[] = "no desc";
 #define CD_ADMIN      "toggle admin-mode"
 #define CD_FORCESTART "force match to start"
 #define CD_FORCEBREAK "force match to end"
+#define CD_FORCEMAP   "force change of map"
 #define CD_PICKUP     "vote for pickup game"
 #define CD_PREWAR     "playerfire before game"
 #define CD_LOCKMAP    "(un)lock current map"
@@ -442,10 +444,10 @@ const char CD_NODESC[] = "no desc";
 #define CD_FAV3_ADD     "........etc.........."
 #define CD_FAV4_ADD     (CD_NODESC) // skip
 #define CD_FAV5_ADD     (CD_NODESC) // skip
-#define CD_FAV6_ADD     (CD_NODESC) // skip 
-#define CD_FAV7_ADD     (CD_NODESC) // skip 
-#define CD_FAV8_ADD     (CD_NODESC) // skip 
-#define CD_FAV9_ADD     (CD_NODESC) // skip 
+#define CD_FAV6_ADD     (CD_NODESC) // skip
+#define CD_FAV7_ADD     (CD_NODESC) // skip
+#define CD_FAV8_ADD     (CD_NODESC) // skip
+#define CD_FAV9_ADD     (CD_NODESC) // skip
 #define CD_FAV10_ADD    (CD_NODESC) // skip
 #define CD_FAV11_ADD    (CD_NODESC) // skip
 #define CD_FAV12_ADD    (CD_NODESC) // skip
@@ -461,11 +463,11 @@ const char CD_NODESC[] = "no desc";
 #define CD_2FAV_GO      "set pov to slot  2"
 #define CD_3FAV_GO      ".......etc........"
 #define CD_4FAV_GO      (CD_NODESC) // skip
-#define CD_5FAV_GO      (CD_NODESC) // skip 
-#define CD_6FAV_GO      (CD_NODESC) // skip 
-#define CD_7FAV_GO      (CD_NODESC) // skip 
-#define CD_8FAV_GO      (CD_NODESC) // skip 
-#define CD_9FAV_GO      (CD_NODESC) // skip 
+#define CD_5FAV_GO      (CD_NODESC) // skip
+#define CD_6FAV_GO      (CD_NODESC) // skip
+#define CD_7FAV_GO      (CD_NODESC) // skip
+#define CD_8FAV_GO      (CD_NODESC) // skip
+#define CD_9FAV_GO      (CD_NODESC) // skip
 #define CD_10FAV_GO     (CD_NODESC) // skip
 #define CD_11FAV_GO     (CD_NODESC) // skip
 #define CD_12FAV_GO     (CD_NODESC) // skip
@@ -701,6 +703,7 @@ cmd_t cmds[] =
 	{ "admin", 						ReqAdmin, 						0, 			CF_BOTH | CF_MATCHLESS | CF_PARAMS, 									CD_ADMIN },
 	{ "forcestart", 				AdminForceStart, 				0, 			CF_BOTH_ADMIN, 															CD_FORCESTART },
 	{ "forcebreak", 				AdminForceBreak, 				0, 			CF_BOTH_ADMIN, 															CD_FORCEBREAK },
+	{ "forcemap",					AdminForceMap,					0,			CF_BOTH_ADMIN | CF_PARAMS,												CD_FORCEMAP },
 	{ "pickup", 					VotePickup, 					0, 			CF_PLAYER, 																CD_PICKUP },
 	{ "prewar", 					TogglePreWar, 					0, 			CF_BOTH_ADMIN, 															CD_PREWAR },
 	{ "lockmap", 					ToggleMapLock, 					0, 			CF_BOTH_ADMIN, 															CD_LOCKMAP },
@@ -1186,7 +1189,7 @@ void redirect()
 // check if players client support params in aliases
 qbool isSupport_Params(gedict_t *p)
 {
-	// seems only ezQuake support 
+	// seems only ezQuake support
 	return (p->ezquake_version > 0 ? true : false); // have no idea at which point ezquake start support it
 }
 
@@ -4930,7 +4933,7 @@ void RandomPickup()
 	vote_check_rpickup(MAX_RPICKUP_RECUSION);
 }
 
-// { spec tracking stuff 
+// { spec tracking stuff
 
 qbool fav_del_do(gedict_t *s, gedict_t *p, char *prefix);
 qbool favx_del_do(gedict_t *s, gedict_t *p, char *prefix);
@@ -5508,14 +5511,14 @@ void AutoTrackRestore()
 }
 // >> start ktpro compatible autotrack
 
-// When issueing this command, KTeams Pro will switch the view to the next_best 
-// player. The view will then automtically switch to the next_best player when 
-// one of the following events occurs: 
+// When issueing this command, KTeams Pro will switch the view to the next_best
+// player. The view will then automtically switch to the next_best player when
+// one of the following events occurs:
 
 // 1. the first rl in the game is taken
 // 2. the player currently being observed dies
 // 3. any player takes a powerup
-// 4. when the currently observed player has a powerup which runs out and he has 
+// 4. when the currently observed player has a powerup which runs out and he has
 //    neither the rocket launcher nor the lightning gun
 
 // will force spec who used ktpro autotrack switch track
@@ -5680,7 +5683,7 @@ void ktpro_autotrack_predict_powerup(void)
 	ktpro_autotrack_on_powerup_predict(best);
 }
 
-// << end  ktpro compatible autotrack 
+// << end  ktpro compatible autotrack
 
 void next_best()
 {
@@ -5771,7 +5774,7 @@ void next_pow()
 	}
 }
 
-// }  spec tracking stuff 
+// }  spec tracking stuff
 
 //================================================
 // pos_show/pos_save/pos_move/pos_set_* commands {
@@ -6830,7 +6833,7 @@ void SetMidairMinHeight()
 		return;
 	}
 
-	// Can't set minheight if midair is not turned on 
+	// Can't set minheight if midair is not turned on
 	if (!cvar("k_midair"))
 	{
 		G_sprint(self, 2, "Midair must be turned on to set minimal frag height\n");
@@ -6920,7 +6923,7 @@ void ToggleInstagib()
 
 	if (k_instagib == 0)
 	{
-		cvar_fset("dmm4_invinc_time", 1.0f); // default invic respawn time is 1s in instagib 
+		cvar_fset("dmm4_invinc_time", 1.0f); // default invic respawn time is 1s in instagib
 	}
 
 	if (++k_instagib > 3)

--- a/src/vote.c
+++ b/src/vote.c
@@ -458,38 +458,27 @@ int vote_get_maps()
 
 void vote_check_map()
 {
-	int vt_req = get_votes_req( OV_MAP, true);
-	char *m = "";
-
-	if ((maps_voted_idx < 0) || strnull(m = GetMapName(maps_voted[maps_voted_idx].map_id)))
+	int vt_req = get_votes_req(OV_MAP, true);
+	if (maps_voted_idx < 0)
 	{
 		return;
 	}
-
-	if (!k_matchLess)
-	{
-		if (match_in_progress)
-		{
-			return;
-		}
-	}
-
-	if (maps_voted[maps_voted_idx].admins)
-	{
-		G_bprint(2, "%s\n", redtext("Admin veto"));
-	}
-	else if (!vt_req)
-	{
-		G_bprint(2, "%s votes for mapchange.\n", redtext("Majority"));
-	}
-	else
+	char *mapname = GetMapName(maps_voted[maps_voted_idx].map_id);
+	if (strnull(mapname))
 	{
 		return;
 	}
-
-	vote_clear( OV_MAP);
-
-	changelevel(m);
+	if (!k_matchLess && match_in_progress)
+	{
+		return;
+	}
+	if (vt_req)
+	{
+		return;
+	}
+	G_bprint(2, "%s votes for mapchange.\n", redtext("Majority"));
+	vote_clear(OV_MAP);
+	changelevel(mapname);
 }
 
 void vote_check_break()

--- a/src/vote.c
+++ b/src/vote.c
@@ -458,24 +458,31 @@ int vote_get_maps()
 
 void vote_check_map()
 {
-	int vt_req = get_votes_req(OV_MAP, true);
+	int vt_req;
+	char *mapname;
+
+	vt_req = get_votes_req(OV_MAP, true);
 	if (maps_voted_idx < 0)
 	{
 		return;
 	}
-	char *mapname = GetMapName(maps_voted[maps_voted_idx].map_id);
+
+	mapname = GetMapName(maps_voted[maps_voted_idx].map_id);
 	if (strnull(mapname))
 	{
 		return;
 	}
+
 	if (!k_matchLess && match_in_progress)
 	{
 		return;
 	}
+
 	if (vt_req)
 	{
 		return;
 	}
+
 	G_bprint(2, "%s votes for mapchange.\n", redtext("Majority"));
 	vote_clear(OV_MAP);
 	changelevel(mapname);


### PR DESCRIPTION
A map vote from an admin will no longer bypass the percentage system
and force the map to change. It will be treated like a regular vote
instead.

If the need to force a change of map arises, there is a new command,
forcemap <mapname>, which does precisely that.

Only admins can execute forcemap, and it will refuse to work if a match
is currently in progress (admins can forcebreak the match first if
necessary).