### PR TITLE
Added the ability to set custom item timings.

### DIFF
--- a/include/g_local.h
+++ b/include/g_local.h
@@ -534,6 +534,9 @@ void DropBackpack();
 
 void adjust_pickup_time(float *current, float *total);
 
+void ResetTimings();
+qbool CustomTimingsActive();
+
 //triggers.c
 void play_teleport(gedict_t *sndspot);
 void spawn_tfog(vec3_t org);

--- a/resources/example-configs/ktx/ktx.cfg
+++ b/resources/example-configs/ktx/ktx.cfg
@@ -121,3 +121,6 @@ set k_spec_info               1         // moreinfo (bit mask):
 set k_sayteam_to_spec         1         // send say_team to specs (0 = never, 1 = only during game, 2 = only during prewar, 3 = always)
 set allow_spec_wizard         0         // allow spectator wizards (0 = no, 1 = only when no players are on the server, 2 = only in prewar)
 set k_no_wizard_animation     0         // wizard animation (0 = on, 1 = off)
+
+// item timings
+set k_allow_custom_timings    0         // allow setting custom item timings (0 = nobody, 1 = admins only, 2 = players only, 3 = players and spectators)

--- a/src/commands.c
+++ b/src/commands.c
@@ -276,6 +276,8 @@ void private_game_toggle(qbool enable);
 
 void ListGameModes(void);
 
+void TimingControl(void);
+
 // Save the first 5 demo markers to print at the end.
 demo_marker_t demo_markers[10];
 int demo_markers_count = 10;
@@ -651,6 +653,8 @@ const char CD_NODESC[] = "no desc";
 
 #define CD_GAMEMODES		"list available game modes"
 
+#define CD_TIMING			"control item timings"
+
 void dummy()
 {
 }
@@ -1008,6 +1012,8 @@ cmd_t cmds[] =
 	{ "voteprivate", 				private_game_vote, 				0, 			CF_PLAYER, 																CD_PRIVATEGAME },
 
 	{ "gamemodes",					ListGameModes,					0,			CF_BOTH,																CD_GAMEMODES },
+
+	{ "timing",						TimingControl,					0,			CF_BOTH | CF_PARAMS,													CD_TIMING },
 };
 
 #undef DEF

--- a/src/items.c
+++ b/src/items.c
@@ -2927,7 +2927,7 @@ void TimingControl()
 	seconds = 0;
 	if (argc > 2)
 	{
-		allow = cvar("allow_custom_timings");
+		allow = cvar("k_allow_custom_timings");
 		if (allow <= 0)
 		{
 			G_sprint(self, 2, "Error: custom timings not allowed on server\n");
@@ -3103,5 +3103,6 @@ qbool CustomTimingsActive()
 			return 1;
 		}
 	}
+
 	return 0;
 }

--- a/src/items.c
+++ b/src/items.c
@@ -40,9 +40,9 @@ enum
 	NUM_ITEM_CLASSES,
 };
 
-static float respawn_times[NUM_ITEM_CLASSES];
+float respawn_times[NUM_ITEM_CLASSES];
 
-static const float default_respawn_times[][NUM_ITEM_CLASSES] =
+const float default_respawn_times[][NUM_ITEM_CLASSES] =
 {
 	{20, 30, 20, 30, 20, 60, 300, 300}, // DMM0
 	{20, 30, 20, 30, 20, 60, 300, 300}, // DMM1

--- a/src/match.c
+++ b/src/match.c
@@ -1238,6 +1238,8 @@ void PrintCountdown(int seconds)
 // Dmgfrags   On // optional
 // Noweapon
 
+// Custom timings  // optional
+
 // Handicap in use // optional
 
 	char text[1024] =
@@ -1489,6 +1491,11 @@ void PrintCountdown(int seconds)
 	{
 		strlcat(text, va("\n%s %4s\n", "Noweapon", redtext(nowp[0] == 32 ? (nowp + 1) : nowp)),
 				sizeof(text));
+	}
+
+	if (CustomTimingsActive())
+	{
+		strlcat(text, va("\n%s\n", redtext("Custom timings")), sizeof(text));
 	}
 
 	if (handicap_in_use())

--- a/src/world.c
+++ b/src/world.c
@@ -212,7 +212,7 @@ void SP_worldspawn()
 
 // the area based ambient sounds MUST be the first precache_sounds
 
-// player precaches     
+// player precaches
 	W_Precache();		// get weapon precaches
 
 // sounds used from C physics code
@@ -269,7 +269,7 @@ void SP_worldspawn()
 
 	trap_precache_sound("boss1/sight1.wav");
 
-// ax sounds    
+// ax sounds
 	trap_precache_sound("weapons/ax1.wav");	// ax swoosh
 	trap_precache_sound("player/axhit1.wav");	// ax hit meat
 	trap_precache_sound("player/axhit2.wav");	// ax hit world
@@ -591,7 +591,7 @@ void Customize_Maps()
 
 	if (!cvar("k_end_tele_spawn") && streq("end", g_globalvars.mapname)
 #ifdef BOT_SUPPORT
-		&& !bots_enabled() 
+		&& !bots_enabled()
 #endif
 		)
 	{
@@ -1685,7 +1685,7 @@ void FixRules()
 	}
 }
 
-int timelimit, fraglimit, teamplay, deathmatch, framecount, coop, skill;
+int timelimit, fraglimit, teamplay, deathmatch, old_deathmatch, framecount, coop, skill;
 
 extern float intermission_exittime;
 
@@ -1711,6 +1711,12 @@ void StartFrame(int time)
 	{
 		SecondFrame();
 		FixRules();
+	}
+
+	if (deathmatch != old_deathmatch)
+	{
+		old_deathmatch = deathmatch;
+		ResetTimings();
 	}
 
 	FixNoSpecs(); // if no players left turn off "no spectators" mode

--- a/src/world.c
+++ b/src/world.c
@@ -1424,6 +1424,8 @@ void FixSayTeamToSpecs()
 
 int skip_fixrules = 0;
 
+static int old_deathmatch = -1;
+
 // check if server is misconfigured somehow, made some minimum fixage
 void FixRules()
 {
@@ -1511,6 +1513,12 @@ void FixRules()
 			&& (deathmatch != 5))
 	{
 		trap_cvar_set_float("deathmatch", (deathmatch = 3));
+	}
+
+	if (deathmatch != old_deathmatch)
+	{
+		old_deathmatch = deathmatch;
+		ResetTimings();
 	}
 
 	if (k_matchLess)
@@ -1685,7 +1693,7 @@ void FixRules()
 	}
 }
 
-int timelimit, fraglimit, teamplay, deathmatch, old_deathmatch, framecount, coop, skill;
+int timelimit, fraglimit, teamplay, deathmatch, framecount, coop, skill;
 
 extern float intermission_exittime;
 
@@ -1711,12 +1719,6 @@ void StartFrame(int time)
 	{
 		SecondFrame();
 		FixRules();
-	}
-
-	if (deathmatch != old_deathmatch)
-	{
-		old_deathmatch = deathmatch;
-		ResetTimings();
 	}
 
 	FixNoSpecs(); // if no players left turn off "no spectators" mode


### PR DESCRIPTION
There is a new command, /timing, which allows players to manage item timings
within certain limitations set by the current deathmatch mode.

Usage
-----

/timing health|ammo|armor|weapon|mega|quad|eyes|pent|all [SECONDS|default]

The workings of the command are best explained using examples.

Example 1.
Change the weapon respawn time from 30 seconds to 15 seconds (assume the
current deathmatch mode is 1):

    ] timing weapon 15

Example 2.
Change the weapon respawn time from 30 seconds to 45 seconds (assume the
current deathmatch mode is 3):

    ] timing weapon 45
    Error: item does not respawn in current deathmatch mode

Notice how the command fails in deathmatch mode 3 because in that mode
weapons don't respawn--they stay permanently on the map.

Example 3.
Fetch the current respawn time for ammo items:

    ] timing ammo
    Ammo respawn time: 15.000s

Example 4.
Set the respawn time for quad to the default value from the current
deathmatch mode:

    ] timing quad default

Example 5.
Set the respawn time for all items to the default values from the current
deathmatch mode:

    ] timing all default

Example 6.
Fetch the current respawn times for all items:

    ] timing all
    Respawn times:
     Health: 20.000s
     Ammo:   15.000s
     Armor:  20.000s
     Weapon: stay
     Mega:   20.000s
     Quad:   60.000s
     Eyes:   300.000s
     Pent:   300.000s

Example 7.
Try to set the respawn time for health to 7500 seconds:

    ] timing health 7500
    Error: duration out of range

The accepted range for SECONDS is [5,1500] (inclusive). Anything outside
of that will result in an error.

Access control
--------------

There is a new server-side cvar, allow_custom_timings, which controls who can
change item respawn times. Anybody can read the current respawn times.

    allow_custom_timings <= 0
    (default; nobody can write new timings)

    allow_custom_timings 1
    (only admins can write new timings)

    allow_custom_timings 2
    (any player, not spectator, can write new timings)

    allow_custom_timings >= 3
    (anybody can write new timings)

Miscellaneous
-------------

Whenever custom timings are in effect, the match countdown screen has a line
that reads "Custom timings" in red. If standard timings are in effect, the
line is not present.

Every time the deathmatch mode changes, custom item timings are reset to
the standard values for that mode.