### PR TITLE
Fix SOCD detection

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -3710,6 +3710,8 @@ void PlayerPreThink(void)
 			{
 				int k_allow_socd_warning = cvar("k_allow_socd_warning");
 
+				self->socdDetectionCount += 1;
+
 				if ((!match_in_progress) && (!self->isBot) && k_allow_socd_warning && (self->ct == ctPlayer) && (self->socdDetectionCount >= 3))
 				{
 					G_bprint(PRINT_HIGH,


### PR DESCRIPTION
The SOCD detection counter was never incremented, resulting in SOCD detections never being reported.