### PR TITLE
Add socd command

### DIFF
--- a/include/g_consts.h
+++ b/include/g_consts.h
@@ -338,3 +338,8 @@ enum
 #define MVDHIDDEN_DMGDONE_SPLASHDAMAGE	(1 << 15)
 
 #define CLIENT_NAME_LEN					32		// Maximum client name, same value as in server.
+
+#define SOCD_ALLOW	0
+#define SOCD_STATS	1
+#define SOCD_WARN	2
+#define SOCD_KICK	3

--- a/src/client.c
+++ b/src/client.c
@@ -3642,6 +3642,7 @@ void PlayerPreThink(void)
 {
 	float r;
 	qbool zeroFps = false;
+	int k_socd = cvar("k_socd");
 
 	if (self->k_timingWarnTime)
 	{
@@ -3708,15 +3709,21 @@ void PlayerPreThink(void)
 		{
 			if (self->fFramePerfectStrafeChangeCount / self->fStrafeChangeCount >= 0.75)
 			{
-				int k_allow_socd_warning = cvar("k_allow_socd_warning");
-
 				self->socdDetectionCount += 1;
 
-				if ((!match_in_progress) && (!self->isBot) && k_allow_socd_warning && (self->ct == ctPlayer) && (self->socdDetectionCount >= 3))
+				if ((!match_in_progress) && (!self->isBot) && k_socd == SOCD_WARN && (self->ct == ctPlayer) && (self->socdDetectionCount >= 3))
 				{
 					G_bprint(PRINT_HIGH,
 						"[%s] Warning! %s: Movement assistance detected. Please disable iDrive or keyboard strafe assistance features.\n",
 						SOCD_DETECTION_VERSION, self->netname);
+				}
+
+				if ((!self->isBot) && k_socd == SOCD_KICK && (self->ct == ctPlayer) && (self->socdDetectionCount >= 3))
+				{
+					G_bprint(PRINT_HIGH,
+						"[%s] Kicked! %s: Movement assistance detected. Please disable iDrive or keyboard strafe assistance features.\n",
+						SOCD_DETECTION_VERSION, self->netname);
+					stuffcmd(self, "disconnect\n");
 				}
 			}
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -274,6 +274,7 @@ void giveme(void);
 static void dropitem(void);
 static void removeitem(void);
 static void dumpent(void);
+static void socd(void);
 // }
 
 // { Frogbots
@@ -660,6 +661,7 @@ const char CD_NODESC[] = "no desc";
 #define CD_DROPITEM			(CD_NODESC) // skip
 #define CD_REMOVEITEM		(CD_NODESC) // skip
 #define CD_DUMPENT			(CD_NODESC) // skip
+#define CD_SOCD			"cycle between SOCD detection modes"
 
 #define CD_VOTECOOP			"vote for coop on/off"
 #define CD_COOPNMPU			"new nightmare mode (pu drops) on/off"
@@ -1035,6 +1037,7 @@ cmd_t cmds[] =
 	{ "dropitem", 					dropitem, 						0, 			CF_BOTH | CF_PARAMS, 													CD_DROPITEM },
 	{ "removeitem", 				removeitem, 					0, 			CF_BOTH | CF_PARAMS, 													CD_REMOVEITEM },
 	{ "dumpent", 					dumpent, 						0, 			CF_BOTH | CF_PARAMS, 													CD_DUMPENT },
+	{ "socd", 					socd, 							0, 			CF_PLAYER,														CD_SOCD },
 	{ "votecoop", 					votecoop, 						0, 			CF_PLAYER | CF_MATCHLESS, 												CD_VOTECOOP },
 	{ "coop_nm_pu", 				ToggleNewCoopNm, 				0, 			CF_PLAYER | CF_MATCHLESS, 												CD_COOPNMPU },
 	{ "demomark", 					DemoMark, 						0, 			CF_BOTH, 																CD_DEMOMARK },
@@ -9346,6 +9349,40 @@ static void dumpent(void)
 	trap_FS_CloseFile(file_handle);
 
 	G_sprint(self, 2, "Dumped %d entities\n", cnt);
+}
+
+static void socd(void)
+{
+	int k_socd;
+
+	if (match_in_progress)
+	{
+		return;
+	}
+
+	k_socd = cvar("k_socd") + 1;
+	if (k_socd < SOCD_ALLOW || k_socd > SOCD_KICK)
+	{
+		k_socd = SOCD_ALLOW;
+	}
+
+	switch (k_socd)
+	{
+		case SOCD_ALLOW:
+			G_bprint(2, "%s: allow\n", redtext("SOCD"));
+			break;
+		case SOCD_STATS:
+			G_bprint(2, "%s: stats after game\n", redtext("SOCD"));
+			break;
+		case SOCD_WARN:
+			G_bprint(2, "%s: warn on violation\n", redtext("SOCD"));
+			break;
+		case SOCD_KICK:
+			G_bprint(2, "%s: kick on violation\n", redtext("SOCD"));
+			break;
+	}
+
+	cvar_set("k_socd", va("%d", (int)k_socd));
 }
 
 qbool lgc_enabled(void)

--- a/src/match.c
+++ b/src/match.c
@@ -1411,6 +1411,7 @@ void PrintCountdown(int seconds)
 	char *ot = "";
 	char *nowp = "";
 	char *matchtag = redtext(ezinfokey(world, "matchtag"));
+	int k_socd = cvar("k_socd");
 
 	strlcat(text, va("%s: %2s\n\n\n", redtext("Countdown"), dig3(seconds)), sizeof(text));
 
@@ -1650,6 +1651,12 @@ void PrintCountdown(int seconds)
 	{
 		strlcat(text, va("%s %4s\n", "Powerups", redtext(Get_PowerupsStr())), sizeof(text));
 	}
+
+	strlcat(text, va("%s %6s\n", SOCD_DETECTION_VERSION,
+		k_socd == SOCD_ALLOW ? redtext("allow")
+		: k_socd == SOCD_STATS ? redtext("stats")
+		: k_socd == SOCD_WARN ? redtext("warn")
+		: redtext("kick")), sizeof(text));
 
 	if (cvar("k_dmgfrags"))
 	{

--- a/src/stats.c
+++ b/src/stats.c
@@ -764,7 +764,7 @@ void OnePlayerStats(gedict_t *p, int tp)
 	}
 
 	// movement
-	if (!p->isBot)
+	if (!p->isBot && cvar("k_socd") >= SOCD_STATS)
 	{
 		G_bprint(2, "%s: %s:%.1f%% (%d/%d) %s:%d/%d%s [%s]\n", redtext("Movement"), redtext("Perfect strafes"),
 			p->matchStrafeChangeCount > 0 ? 100.0 * p->matchPerfectStrafeCount / p->matchStrafeChangeCount : 0.0,

--- a/src/world.c
+++ b/src/world.c
@@ -1007,7 +1007,7 @@ void FirstFrame(void)
 
 	RegisterCvar("k_teamoverlay"); // q3 like team overlay
 
-	RegisterCvar("k_allow_socd_warning"); // socd
+	RegisterCvarEx("k_socd", "1");
 
 // { SP
 	RegisterCvarEx("k_monster_spawn_time", "20");


### PR DESCRIPTION
The new command allows users to cycle between different SOCD detection modes:

- Allow: Allow SOCD
- Stats: Collect SOCD detection stats and print when the game ends
- Warn: Display a warning when SOCD detection is triggered
- Kick: Kick the player if SOCD detection is triggered