### PR TITLE
Add item pickup bonus for ToT mode

### DIFF
--- a/include/fb_globals.h
+++ b/include/fb_globals.h
@@ -367,6 +367,7 @@ int FrogbotSkillLevel(void);
 int FrogbotHealth(void);
 int FrogbotWeapon(void);
 int FrogbotQuadMultiplier(void);
+qbool FrogbotItemPickupBonus(void);
 
 // botthink.qc
 void SetMarker(gedict_t *client, gedict_t *marker);
@@ -393,19 +394,20 @@ void RunRandomTrials(float min, float max, float mult);
 // editor
 qbool HasSavedMarker(void);
 
-#define FB_CVAR_ENABLED         "k_fb_enabled"
-#define FB_CVAR_OPTIONS         "k_fb_options"
-#define FB_CVAR_AUTOADD_LIMIT   "k_fb_autoadd_limit"
-#define FB_CVAR_AUTOREMOVE_AT   "k_fb_autoremove_at"
-#define FB_CVAR_AUTO_DELAY      "k_fb_auto_delay"
-#define FB_CVAR_SKILL           "k_fb_skill"
-#define FB_CVAR_DEBUG           "k_fb_debug"
-#define FB_CVAR_ADMIN_ONLY      "k_fb_admin_only"
-#define FB_CVAR_FREEZE_PREWAR   "k_fb_freeze_prewar"
-#define FB_CVAR_HEALTH          "k_fb_health"
-#define FB_CVAR_WEAPON          "k_fb_weapon"
-#define FB_CVAR_BREAK_ON_DEATH  "k_fb_break_on_death"
-#define FB_CVAR_QUAD_MULTIPLIER "k_fb_quad_multiplier"
+#define FB_CVAR_ENABLED           "k_fb_enabled"
+#define FB_CVAR_OPTIONS           "k_fb_options"
+#define FB_CVAR_AUTOADD_LIMIT     "k_fb_autoadd_limit"
+#define FB_CVAR_AUTOREMOVE_AT     "k_fb_autoremove_at"
+#define FB_CVAR_AUTO_DELAY        "k_fb_auto_delay"
+#define FB_CVAR_SKILL             "k_fb_skill"
+#define FB_CVAR_DEBUG             "k_fb_debug"
+#define FB_CVAR_ADMIN_ONLY        "k_fb_admin_only"
+#define FB_CVAR_FREEZE_PREWAR     "k_fb_freeze_prewar"
+#define FB_CVAR_HEALTH            "k_fb_health"
+#define FB_CVAR_WEAPON            "k_fb_weapon"
+#define FB_CVAR_BREAK_ON_DEATH    "k_fb_break_on_death"
+#define FB_CVAR_QUAD_MULTIPLIER   "k_fb_quad_multiplier"
+#define FB_CVAR_ITEM_PICKUP_BONUS "k_fb_item_pickup_bonus"
 
 void BotsFireLogic(void);
 

--- a/src/bot_commands.c
+++ b/src/bot_commands.c
@@ -130,6 +130,11 @@ int FrogbotQuadMultiplier(void)
 	return (int)cvar(FB_CVAR_QUAD_MULTIPLIER);
 }
 
+qbool FrogbotItemPickupBonus(void)
+{
+	return tot_mode_enabled() && (qbool)cvar(FB_CVAR_ITEM_PICKUP_BONUS);
+}
+
 static team_t* AddTeamToList(int *teamsFound, char *team, int topColor, int bottomColor)
 {
 	int i;
@@ -2263,6 +2268,25 @@ static void FrogbotsSetQuadMultiplier(void)
 	}
 }
 
+static void FrogbotsSetItemPickupBonus(void)
+{
+	if (!bots_enabled())
+	{
+		G_sprint(self, 2, "Bots are disabled by the server.\n");
+		return;
+	}
+
+	if (!tot_mode_enabled())
+	{
+		G_sprint(self, 2, "This is option is only available in ToT mode.\n");
+		return;
+	}
+
+	cvar_fset(FB_CVAR_ITEM_PICKUP_BONUS, !cvar(FB_CVAR_ITEM_PICKUP_BONUS));
+	G_sprint(self, 2, "item pickup bonus changed to %s\n",
+		(int)cvar(FB_CVAR_ITEM_PICKUP_BONUS) ? redtext("on") : redtext("off"));
+}
+
 typedef struct frogbot_cmd_s
 {
 	char *name;
@@ -2283,7 +2307,8 @@ static frogbot_cmd_t std_commands[] =
 		{ "weapon", FrogbotsSetWeapon, "Set which weapon the bot should use" },
 		{ "breakondeath", FrogbotsSetBreakOnDeath, "Automatically break when you die" },
 		{ "togglequad", FrogbotsToggleQuad, "Toggle quad damage" },
-		{ "quadmultiplier", FrogbotsSetQuadMultiplier, "Set quad damage multiplier" }};
+		{ "quadmultiplier", FrogbotsSetQuadMultiplier, "Set quad damage multiplier" },
+		{ "itempickupbonus", FrogbotsSetItemPickupBonus, "Toggle item pickup bonus" }};
 
 static frogbot_cmd_t editor_commands[] =
 	{

--- a/src/match.c
+++ b/src/match.c
@@ -864,22 +864,74 @@ void SM_PrepareMap(void)
 
 		if (deathmatch >= 4)
 		{
-			if (streq(p->classname, "weapon_nailgun") || streq(p->classname, "weapon_supernailgun")
-					|| streq(p->classname, "weapon_supershotgun")
-					|| streq(p->classname, "weapon_rocketlauncher")
-					|| streq(p->classname, "weapon_grenadelauncher")
-					|| streq(p->classname, "weapon_lightning"))
-			{ // no weapons for any of this deathmatches (4 or 5)
+			int disallowed_weapons = (int)cvar("k_disallow_weapons") & DA_WPNS;
+
+			// no weapons for any of this deathmatches (4 or 5),
+			// unless ToT mode with item pickup bonus is enabled and
+			// the weapon isn't disallowed.
+			if (streq(p->classname, "weapon_nailgun"))
+			{
+				soft_ent_remove(p);
+				continue;
+			}
+			else if (streq(p->classname, "weapon_supernailgun"))
+			{
+				soft_ent_remove(p);
+				continue;
+			}
+			else if (streq(p->classname, "weapon_supershotgun"))
+			{
+				soft_ent_remove(p);
+				continue;
+			}
+			else if (streq(p->classname, "weapon_grenadelauncher"))
+			{
+				soft_ent_remove(p);
+				continue;
+			}
+			else if (streq(p->classname, "weapon_rocketlauncher") &&
+				(!FrogbotItemPickupBonus() ||
+				(disallowed_weapons & IT_ROCKET_LAUNCHER)))
+			{
+				soft_ent_remove(p);
+				continue;
+			}
+			else if (streq(p->classname, "weapon_lightning") &&
+				(!FrogbotItemPickupBonus() ||
+				(disallowed_weapons & IT_LIGHTNING)))
+			{
 				soft_ent_remove(p);
 				continue;
 			}
 
 			if (deathmatch == 4)
 			{
-				if (streq(p->classname, "item_shells") || streq(p->classname, "item_spikes")
-						|| streq(p->classname, "item_rockets") || streq(p->classname, "item_cells")
-						|| (streq(p->classname, "item_health") && ((int)p->s.v.spawnflags & H_MEGA)))
-				{ // no weapon ammo and megahealth for dmm4
+				// no weapon ammo and megahealth for dmm4
+				if (streq(p->classname, "item_shells"))
+				{
+					soft_ent_remove(p);
+					continue;
+				}
+				else if (streq(p->classname, "item_spikes"))
+				{
+					soft_ent_remove(p);
+					continue;
+				}
+				else if (streq(p->classname, "item_rockets") &&
+					!FrogbotItemPickupBonus())
+				{
+					soft_ent_remove(p);
+					continue;
+				}
+				else if (streq(p->classname, "item_cells"))
+				{
+					soft_ent_remove(p);
+					continue;
+				}
+				else if ((streq(p->classname, "item_health") &&
+					((int)p->s.v.spawnflags & H_MEGA)) &&
+					!FrogbotItemPickupBonus())
+				{
 					soft_ent_remove(p);
 					continue;
 				}
@@ -1710,6 +1762,9 @@ void PrintCountdown(int seconds)
 		strlcat(text, va("Bot health %15s\n", dig3(FrogbotHealth())), sizeof(text));
 		strlcat(text, va("Bot skill %16s\n", dig3(FrogbotSkillLevel())), sizeof(text));
 		strlcat(text, va("Quad damage multiplier %3s\n", dig3(FrogbotQuadMultiplier())), sizeof(text));
+		strlcat(text, va("Item Pickup Bonus %8s\n",
+			redtext(FrogbotItemPickupBonus() ? "on": "off")), sizeof(text));
+
 	}
 
 	if (matchtag[0])

--- a/src/world.c
+++ b/src/world.c
@@ -1057,6 +1057,7 @@ void FirstFrame(void)
 	RegisterCvarEx(FB_CVAR_WEAPON, "2");
 	RegisterCvarEx(FB_CVAR_BREAK_ON_DEATH, "1");
 	RegisterCvarEx(FB_CVAR_QUAD_MULTIPLIER, "4");
+	RegisterCvarEx(FB_CVAR_ITEM_PICKUP_BONUS, "0");
 
 	for (i = 0; i < MAX_CLIENTS; i++)
 	{


### PR DESCRIPTION
This introduces a new mode when playing the ToT mode that aims to help you practice item timings.

When picking up any of the following items, you will receive an additional 100 health:

- lg
- rl
- mega
- rockets