### PR TITLE
Allow pause without matchtag if k_pause_without_matchtag is set

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -5734,10 +5734,10 @@ qbool PlayerCanPause(gedict_t *p)
 	qbool playerCanPause = false;
 	char *matchtag = ezinfokey(world, "matchtag");
 
-	// Check for matchtag. If it is set, it is an official (probably), so pause might be allowed.
-	if ((NULL != matchtag) && matchtag[0])
+	// Check for matchtag, OR allow if k_pause_without_matchtag is set.
+	if (cvar("k_pause_without_matchtag") || ((matchtag != NULL) && matchtag[0]))
 	{
-		// matchtag is found. Let's see if the player can still pause.
+		// Let's see if the player can still pause.
 		if (p->k_pauseRequests > 0)
 		{
 			p->k_pauseRequests--;

--- a/src/world.c
+++ b/src/world.c
@@ -785,6 +785,7 @@ void FirstFrame(void)
 	RegisterCvar("_k_nospecs");  // internal usage, will reject spectators connection
 
 	RegisterCvar("k_noitems");
+	RegisterCvarEx("k_pause_without_matchtag", "0");
 
 	RegisterCvar("k_random_maplist"); // select random map from k_ml_XXX variables.
 


### PR DESCRIPTION
Previously, players could only pause if a matchtag was set. This change adds support for the cvar k_pause_without_matchtag. When enabled, the check for matchtag is skipped, and players can use their available pause requests regardless of whether the game has a matchtag.