### PR TITLE
Golden frag sudden death

### DIFF
--- a/include/g_consts.h
+++ b/include/g_consts.h
@@ -302,6 +302,10 @@
 // k_sudden_death types
 #define SD_NORMAL						(1)
 #define SD_TIEBREAK						(2)
+#define SD_GOLDEN_FRAG					(4)
+
+
+#define GOLDEN_FRAG_SNAPSHOT_INITIAL_VALUE (9999)
 
 //
 #define CALLALIAS_SIZE					(128)

--- a/include/g_local.h
+++ b/include/g_local.h
@@ -1259,6 +1259,21 @@ qbool AllowMonster(gedict_t *e);
 #define SPAWN_SHOW_PREWAR 1
 #define SPAWN_SHOW_MATCH 2
 
+/**
+ * Stores the score state used to evaluate golden-frag overtime.
+ *
+ * The snapshot represents the score difference at the moment golden-frag
+ * tracking starts or is refreshed. A later score difference can be compared
+ * against this snapshot to determine whether a frag changed the lead enough
+ * to end the match.
+ */
+typedef struct {
+	int team1_score;
+	int team2_score;
+} golden_frag_score_snapshot_t;
+
+extern golden_frag_score_snapshot_t golden_frag_score_snapshot;
+
 #define SPAWNICIDE_DISABLED 0
 #define SPAWNICIDE_PREWAR 1
 #define SPAWNICIDE_MATCH 2

--- a/src/client.c
+++ b/src/client.c
@@ -2418,10 +2418,77 @@ int tiecount(void)
 	return (deathmatch == 4 ? 2 : 3);
 }
 
+/**
+ * Gets the absolute score difference from the golden frag snapshot.
+ * @return The absolute difference between team1 and team2 snapshot scores.
+ */
+int GetGoldenFragSnapshotDifference(void)
+{
+	return abs(golden_frag_score_snapshot.team1_score - golden_frag_score_snapshot.team2_score);
+}
+
+/**
+ * Checks if the current game mode is solo (duel or FFA).
+ * @return true if the mode is duel or FFA, false otherwise.
+ */
+qbool isDuelOrFFA(void) {
+	return (isDuel() || isFFA());
+}
+
+/**
+ * Gets the current absolute frag difference between the top two players / teams.
+ * @return The absolute difference in frags. For solo modes (duel/FFA), returns difference
+ *         between the top two players' frags. For team modes, returns difference between team scores.
+ */
+int GetCurrentFragDifference(void) {
+	if (isDuelOrFFA()) {
+		const gedict_t *ed1 = get_ed_scores1();
+		const gedict_t *ed2 = get_ed_scores2();
+		if (ed1 && ed2) {
+			return abs((int)ed1->s.v.frags - (int)ed2->s.v.frags);
+		}
+	}
+	return abs(get_scores1() - get_scores2());
+}
+
+/**
+ * Checks if the golden frag snapshot should be updated mid-match.
+ * @return true if k_overtime is set to SD_GOLDEN_FRAG but k_sudden_death is not yet,
+ *         indicating the match is still in regulation but will use golden frag for overtime.
+ */
+qbool shouldUpdateGoldenFragMidMatch(void) {
+	return (int) cvar("k_overtime") == SD_GOLDEN_FRAG
+	       && (int) k_sudden_death != SD_GOLDEN_FRAG;
+}
+
+/**
+ * Updates the golden frag score snapshot with current scores.
+ * For solo modes (duel/FFA), stores individual player frags.
+ *          For team modes, stores team scores. This snapshot is used to track
+ *          the score difference when golden frag overtime begins.
+ */
+void updateGoldenFragSnapshot(void) {
+	if (isDuelOrFFA()) {
+		const gedict_t *ed1 = get_ed_scores1();
+		const gedict_t *ed2 = get_ed_scores2();
+		if (ed1 && ed2) {
+			golden_frag_score_snapshot.team1_score = (int) ed1->s.v.frags;
+			golden_frag_score_snapshot.team2_score = (int) ed2->s.v.frags;
+		}
+	} else {
+		golden_frag_score_snapshot.team1_score = get_scores1();
+		golden_frag_score_snapshot.team2_score = get_scores2();
+	}
+}
+
 // check sudden death end
 // call this on player death
 void Check_SD(gedict_t *p)
 {
+	if (shouldUpdateGoldenFragMidMatch()) {
+		updateGoldenFragSnapshot();
+	}
+
 	if (!match_in_progress)
 	{
 		return;
@@ -2462,6 +2529,15 @@ void Check_SD(gedict_t *p)
 				EndMatch(0);
 			}
 			return;
+		}
+
+		case SD_GOLDEN_FRAG: {
+			// End when the leader extends the frag lead
+			if (GetCurrentFragDifference() > GetGoldenFragSnapshotDifference()) {
+				EndMatch(0);
+			} else {
+				updateGoldenFragSnapshot();
+			}
 		}
 	}
 }

--- a/src/commands.c
+++ b/src/commands.c
@@ -1729,7 +1729,7 @@ void ChangeOvertime(void)
 		return;
 	}
 
-	f1 = bound(0, cvar("k_overtime"), 3);
+	f1 = bound(0, cvar("k_overtime"), 4);
 	f2 = bound(0, cvar("k_exttime"), 999);
 
 	if (!f1)
@@ -1755,6 +1755,11 @@ void ChangeOvertime(void)
 		G_bprint(2, "%s: tie-break\n", redtext("Overtime"));
 	}
 	else if (f1 == 3)
+	{
+		cvar_fset("k_overtime", SD_GOLDEN_FRAG);
+		G_bprint(2, "%s: golden frag\n", redtext("Overtime"));
+	}
+	else if (f1 == SD_GOLDEN_FRAG)
 	{
 		cvar_fset("k_overtime", 0);
 		G_bprint(2, "%s: off\n", redtext("Overtime"));
@@ -1996,6 +2001,10 @@ void ModStatus2(void)
 
 		case 3:
 			ot = va("%d tie-break", tiecount());
+			break;
+
+		case SD_GOLDEN_FRAG:
+			ot = va("golden frag");
 			break;
 
 		default:

--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -2652,6 +2652,9 @@ char* SD_type_str(void)
 		case SD_TIEBREAK:
 			return "tie-break";
 
+		case SD_GOLDEN_FRAG:
+			return "Golden Frag";
+
 		default:
 			return "unknown";
 	}

--- a/src/globals.c
+++ b/src/globals.c
@@ -112,3 +112,9 @@ float lastTeamLocationTime;		// next udate for CheckTeamStatus()
 qbool first_rl_taken;			// true when some one alredy took rl
 
 int sv_minping;					// used to broadcast changes
+
+ // { golden frag, setup with values that return large absolute value
+golden_frag_score_snapshot_t golden_frag_score_snapshot = {
+ -GOLDEN_FRAG_SNAPSHOT_INITIAL_VALUE, GOLDEN_FRAG_SNAPSHOT_INITIAL_VALUE
+};
+ // }

--- a/src/match.c
+++ b/src/match.c
@@ -532,7 +532,7 @@ void CheckOvertime(void)
 
 	// If 0 no overtime, 1 overtime, 2 sudden death
 	// And if its neither then well we exit
-	if (!k_mb_overtime || ((k_mb_overtime != 1) && (k_mb_overtime != 2) && (k_mb_overtime != 3)))
+	if (!k_mb_overtime || ((k_mb_overtime != 1) && (k_mb_overtime != 2) && (k_mb_overtime != 3) && (k_mb_overtime != SD_GOLDEN_FRAG)))
 	{
 		EndMatch(0);
 
@@ -565,7 +565,8 @@ void CheckOvertime(void)
 			|| ((isTeam() || isCTF()) && (teams == 2) && (players > 1))) // Handle a 2v2 or above team game or 1v1 CTF
 	{
 		if (((k_mb_overtime == 3) && abs(sc) > 1) // tie-break overtime allowed with one frag difference (c) ktpro
-			|| ((k_mb_overtime != 3) && abs(sc) > 0)) // time based or sudden death overtime allowed with zero frag difference
+			|| (k_mb_overtime != 3 && k_mb_overtime != SD_GOLDEN_FRAG && abs(sc) > 0)) // time based
+				//or sudden death overtime not including golden frag allowed with zero frag difference
 		{
 			k_mb_overtime = 0;
 		}
@@ -601,6 +602,10 @@ void CheckOvertime(void)
 	else if (k_overtime == 2)
 	{
 		k_sudden_death = SD_NORMAL;
+		match_end_time = 0;
+	}
+	else if (k_overtime == SD_GOLDEN_FRAG) {
+		k_sudden_death = SD_GOLDEN_FRAG;
 		match_end_time = 0;
 	}
 	else
@@ -1700,6 +1705,10 @@ void PrintCountdown(int seconds)
 
 		case 3:
 			ot = va("%s %s", dig3(tiecount()), redtext("tb"));
+			break;
+
+		case SD_GOLDEN_FRAG:
+			ot = va("gold");
 			break;
 
 		default:


### PR DESCRIPTION
This is an attempt to partially add the mechanics of golden frag duel rules from Diabotical.

Only sudden death part of the rules were implemented the timer remains the same.

Rules:

- When the timer ends the game goes into sudden death regardless of the result.
- If the leading player manages to increase the frag lead by any means the game ends with leader as the winner (this also includes self frags).
- If the trailing player manages to catch up to the leading player and overtakes him he wins the game.

Q&A
Q: Why use this rule over standard time limit with overtime? 
A: It rewards frag chasing and extending the frag lead from the learder's perspective. Prevents the leader from forcing a win by running away and not confronting his opponent till the time runs out. Also allows for the trailing player to clutch and comeback with worse odds despite the time running out completely. The time limit ending can be another mechanic which players can play around in example the leader can wait with his attack for the time to run out and instantly win the game with single frag in the sudden death. 