### PR TITLE
link missing field offset to `trigger_heal` properties

### DIFF
--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -181,7 +181,8 @@ field_t fields[] =
 	{ "volume", 					FOFS(volume), 						F_FLOAT },
 
 // trigger_heal
-	{ "heal_amount", 				FOFS(healamount), 					F_FLOAT },
+	{ "heal_amount", 				FOFS(healamount),						F_FLOAT },
+	{ "health_max", 				FOFS(healmax),							F_FLOAT },
 // Colorized entities in map
 	{ "colormod" 					-1, 								F_VECTOR },
 	{ NULL }


### PR DESCRIPTION
missing `health_max` link for `trigger_heal` (max heal amount is always 100 / cannot be overriden as documented)